### PR TITLE
feat(ce-mcp-bridge): Add next scan and memory write operations

### DIFF
--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -321,6 +321,26 @@ def scan_all(value: str, type: str = "exact", protection: str = "+W-C") -> str:
 def get_scan_results(max: int = 100) -> str:
     """Get results from the last 'scan_all' operation. Use 'max' to limit output."""
     return format_result(ce_client.send_command("get_scan_results", {"max": max}))
+@mcp.tool()
+def next_scan(value: str, scan_type: str = "exact") -> str:
+    """Next scan to filter results. Types: exact, increased, decreased, changed, unchanged, bigger, smaller."""
+    return format_result(ce_client.send_command("next_scan", {"value": value, "scan_type": scan_type}))
+
+@mcp.tool()
+def write_integer(address: str, value: int, type: str = "dword") -> str:
+    """Write a number to memory. Types: byte, word, dword, qword, float, double."""
+    return format_result(ce_client.send_command("write_integer", {"address": address, "value": value, "type": type}))
+
+@mcp.tool()
+def write_memory(address: str, bytes: list[int]) -> str:
+    """Write raw bytes to memory."""
+    return format_result(ce_client.send_command("write_memory", {"address": address, "bytes": bytes}))
+
+@mcp.tool()
+def write_string(address: str, value: str, wide: bool = False) -> str:
+    """Write a string to memory (ASCII or Wide/UTF-16)."""
+    return format_result(ce_client.send_command("write_string", {"address": address, "value": value, "wide": wide}))
+
 
 @mcp.tool()
 def aob_scan(pattern: str, protection: str = "+X", limit: int = 100) -> str:


### PR DESCRIPTION
- Add cmd_next_scan function to filter previous scan results by value changes
- Add cmd_write_integer function to write numeric values (byte, word, dword, qword, float, double)
- Add cmd_write_memory function to write raw bytes to memory addresses
- Add cmd_write_string function to write ASCII or UTF-16 strings to memory
- Register new command handlers in commandHandlers table
- Export new tools to Python MCP interface (next_scan, write_integer, write_memory, write_string)
- Enables memory modification capabilities for Cheat Engine MCP bridge