### PR TITLE
feat: harden MCP bridge and add file-based script helpers

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -128,6 +128,63 @@ local function captureStack(depth)
     return stack
 end
 
+-- Destroy scan objects safely to avoid leaking memscan/foundlist across runs.
+local function cleanupScanObjects()
+    local cleaned = { memscan = 0, foundlist = 0 }
+
+    if serverState.scan_foundlist then
+        pcall(function() serverState.scan_foundlist.destroy() end)
+        serverState.scan_foundlist = nil
+        cleaned.foundlist = 1
+    end
+
+    if serverState.scan_memscan then
+        pcall(function() serverState.scan_memscan.destroy() end)
+        serverState.scan_memscan = nil
+        cleaned.memscan = 1
+    end
+
+    return cleaned
+end
+
+-- Remove tracked breakpoint state by id and optionally detach CE breakpoint.
+local function clearTrackedBreakpointById(bpId, removeCeBreakpoint)
+    if not bpId then return false end
+
+    local bp = serverState.breakpoints[bpId]
+    if not bp then return false end
+
+    if removeCeBreakpoint and bp.address then
+        pcall(function() debug_removeBreakpoint(bp.address) end)
+    end
+
+    if bp.slot then
+        serverState.hw_bp_slots[bp.slot] = nil
+    end
+
+    serverState.breakpoints[bpId] = nil
+    serverState.breakpoint_hits[bpId] = nil
+    return true
+end
+
+-- Remove all tracked breakpoints that point to the same address.
+local function clearTrackedBreakpointsByAddress(addr, removeCeBreakpoint)
+    if not addr then return 0 end
+
+    local ids = {}
+    for id, bp in pairs(serverState.breakpoints) do
+        if bp.address == addr then
+            table.insert(ids, id)
+        end
+    end
+
+    for _, id in ipairs(ids) do
+        clearTrackedBreakpointById(id, removeCeBreakpoint)
+    end
+
+    return #ids
+end
+
 -- ============================================================================
 -- CLEANUP & SAFETY ROUTINES (CRITICAL FOR ROBUSTNESS)
 -- ============================================================================
@@ -158,15 +215,8 @@ local function cleanupZombieState()
     end
 
     -- 3. Cleanup Scan memory objects
-    if serverState.scan_memscan then
-        pcall(function() serverState.scan_memscan.destroy() end)
-        serverState.scan_memscan = nil
-        cleaned.scans = cleaned.scans + 1
-    end
-    if serverState.scan_foundlist then
-        pcall(function() serverState.scan_foundlist.destroy() end)
-        serverState.scan_foundlist = nil
-    end
+    local scanCleaned = cleanupScanObjects()
+    cleaned.scans = scanCleaned.memscan + scanCleaned.foundlist
 
     -- Reset all tracking tables
     serverState.breakpoints = {}
@@ -627,6 +677,9 @@ end
 local function cmd_scan_all(params)
     local value = params.value
     local vtype = params.type or "dword"
+
+    -- Ensure old scans are released before creating a new one.
+    cleanupScanObjects()
     
     local ms = createMemScan()
     local scanOpt = soExactValue
@@ -712,7 +765,8 @@ local function cmd_next_scan(params)
     ms.waitTillDone()
     
     if serverState.scan_foundlist then
-        serverState.scan_foundlist.destroy()
+        pcall(function() serverState.scan_foundlist.destroy() end)
+        serverState.scan_foundlist = nil
     end
     local fl = createFoundList(ms)
     fl.initialize()
@@ -1129,6 +1183,10 @@ local function cmd_set_breakpoint(params)
     if not addr then return { success = false, error = "Invalid address" } end
     
     bpId = bpId or tostring(addr)
+
+    -- Prevent slot leaks when replacing an existing breakpoint by id or address.
+    clearTrackedBreakpointsByAddress(addr, true)
+    clearTrackedBreakpointById(bpId, true)
     
     -- Find free hardware slot (max 4 debug registers)
     local slot = nil
@@ -1142,9 +1200,6 @@ local function cmd_set_breakpoint(params)
     if not slot then
         return { success = false, error = "No free hardware breakpoint slots (max 4 debug registers)" }
     end
-    
-    -- Remove existing breakpoint at this address
-    pcall(function() debug_removeBreakpoint(addr) end)
     
     serverState.breakpoint_hits[bpId] = {}
     
@@ -1186,6 +1241,10 @@ local function cmd_set_data_breakpoint(params)
     if not addr then return { success = false, error = "Invalid address" } end
     
     bpId = bpId or tostring(addr)
+
+    -- Prevent slot leaks when replacing an existing breakpoint by id or address.
+    clearTrackedBreakpointsByAddress(addr, true)
+    clearTrackedBreakpointById(bpId, true)
     
     -- Find free hardware slot (max 4 debug registers)
     local slot = nil
@@ -1238,14 +1297,7 @@ local function cmd_remove_breakpoint(params)
     local bpId = params.id
     
     if bpId and serverState.breakpoints[bpId] then
-        local bp = serverState.breakpoints[bpId]
-        pcall(function() debug_removeBreakpoint(bp.address) end)
-        
-        if bp.slot then
-            serverState.hw_bp_slots[bp.slot] = nil
-        end
-        
-        serverState.breakpoints[bpId] = nil
+        clearTrackedBreakpointById(bpId, true)
         return { success = true, id = bpId }
     end
     
@@ -1288,14 +1340,18 @@ local function cmd_list_breakpoints(params)
 end
 
 local function cmd_clear_all_breakpoints(params)
-    local count = 0
-    for id, bp in pairs(serverState.breakpoints) do
-        pcall(function() debug_removeBreakpoint(bp.address) end)
-        count = count + 1
+    local ids = {}
+    for id, _ in pairs(serverState.breakpoints) do
+        table.insert(ids, id)
     end
-    serverState.breakpoints = {}
-    serverState.breakpoint_hits = {}
-    serverState.hw_bp_slots = {}
+
+    local count = 0
+    for _, id in ipairs(ids) do
+        if clearTrackedBreakpointById(id, true) then
+            count = count + 1
+        end
+    end
+
     return { success = true, removed = count }
 end
 
@@ -1305,6 +1361,7 @@ end
 
 local function cmd_evaluate_lua(params)
     local code = params.code
+    local serializeResult = params.serialize_result or false
     if not code then return { success = false, error = "No code provided" } end
     
     local fn, err = loadstring(code)
@@ -1313,7 +1370,22 @@ local function cmd_evaluate_lua(params)
     local ok, result = pcall(fn)
     if not ok then return { success = false, error = "Runtime error: " .. tostring(result) } end
     
-    return { success = true, result = tostring(result) }
+    local resultType = type(result)
+    if serializeResult then
+        return {
+            success = true,
+            result = result,
+            result_type = resultType,
+            serialized = true
+        }
+    end
+
+    return {
+        success = true,
+        result = result ~= nil and tostring(result) or nil,
+        result_type = resultType,
+        serialized = false
+    }
 end
 
 -- ============================================================================
@@ -1923,7 +1995,7 @@ end
 -- This is CRITICAL for continuous packet monitoring - logs can be polled repeatedly
 local function cmd_poll_dbvm_watch(params)
     local addr = params.address
-    local clear = params.clear or true  -- Default to clearing logs after poll
+    local clear = params.clear ~= false  -- Default true; explicit false is respected
     local max_results = params.max_results or 1000
     
     if type(addr) == "string" then addr = getAddressSafe(addr) end
@@ -1979,6 +2051,7 @@ local function cmd_poll_dbvm_watch(params)
         virtual_address = toHex(addr),
         physical_address = toHex(watchInfo.physical),
         mode = watchInfo.mode,
+        clear_requested = clear,
         uptime_seconds = uptime,
         hit_count = #results,
         hits = results,
@@ -2191,9 +2264,12 @@ local function PipeWorker(thread)
         -- note: acceptConnection might not return a boolean, so we check pipe.Connected afterwards.
         
         -- log("Thread: Calling acceptConnection()...")
-        pcall(function()
+        local okAccept, acceptErr = pcall(function()
             pipe.acceptConnection()
         end)
+        if (not okAccept) and (not thread.Terminated) then
+            log("Thread: acceptConnection failed: " .. tostring(acceptErr))
+        end
         
         if pipe.Connected and not thread.Terminated then
             log("Client Connected")
@@ -2209,9 +2285,9 @@ local function PipeWorker(thread)
                     
                     -- Sanity check length
                     if len > 0 and len < 100 * 1024 * 1024 then
-                        local payload = pipe.readString(len)
+                        local okPayload, payload = pcall(function() return pipe.readString(len) end)
                         
-                        if payload then
+                        if okPayload and payload then
                             -- CRITICAL: EXECUTE ON MAIN THREAD
                             -- We pause the worker and run logic on GUI thread to be safe
                             local response = nil
@@ -2226,17 +2302,45 @@ local function PipeWorker(thread)
                                 local b2 = math.floor(rLen / 256) % 256
                                 local b3 = math.floor(rLen / 65536) % 256
                                 local b4 = math.floor(rLen / 16777216) % 256
-                                
-                                pipe.writeBytes({b1, b2, b3, b4})
-                                pipe.writeString(response)
+
+                                local okWriteHeader = pcall(function()
+                                    pipe.writeBytes({b1, b2, b3, b4})
+                                end)
+                                if not okWriteHeader then
+                                    if not thread.Terminated then
+                                        log("Thread: writeBytes failed, reconnecting client")
+                                    end
+                                    break
+                                end
+
+                                local okWriteBody = pcall(function()
+                                    pipe.writeString(response)
+                                end)
+                                if not okWriteBody then
+                                    if not thread.Terminated then
+                                        log("Thread: writeString failed, reconnecting client")
+                                    end
+                                    break
+                                end
                             end
                         else
-                             -- log("Thread: Read payload failed (nil)")
+                            if not thread.Terminated then
+                                log("Thread: readString failed, reconnecting client")
+                            end
+                            break
                         end
+                    else
+                        if not thread.Terminated then
+                            log("Thread: invalid payload length (" .. tostring(len) .. "), reconnecting client")
+                        end
+                        break
                     end
                 else
                     -- Read failed. If pipe disconnected, the loop will terminate on next check.
-                    if not pipe.Connected then
+                    if pipe.Connected and not thread.Terminated then
+                        log("Thread: readBytes failed while connected, reconnecting client")
+                        break
+                    elseif not pipe.Connected then
                         -- Client disconnected gracefully
                     end
                 end

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -89,12 +89,16 @@ sys.stdout = sys.stderr
 import json
 import struct
 import time
+import threading
 import traceback
+from pathlib import Path
 
 try:
     import win32file
     import win32pipe
     import win32con
+    import win32event
+    import win32api
     import pywintypes
     from mcp.server.fastmcp import FastMCP
     
@@ -130,96 +134,272 @@ def format_result(result):
 # ============================================================================
 
 # V11 Bridge uses 'CE_MCP_Bridge_v99'
-PIPE_NAME = r"\\.\pipe\CE_MCP_Bridge_v99"
-MCP_SERVER_NAME = "cheatengine"
+DEFAULT_PIPE_NAME = "CE_MCP_Bridge_v99"
+
+
+def _read_int_env(name: str, default: int) -> int:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    try:
+        return int(raw_value)
+    except ValueError:
+        debug_log(f"Invalid integer for {name}: {raw_value!r}. Falling back to {default}.")
+        return default
+
+
+def _normalize_pipe_name(pipe_name: str | None) -> str:
+    if not pipe_name:
+        pipe_name = DEFAULT_PIPE_NAME
+    if pipe_name.startswith("\\\\.\\pipe\\"):
+        return pipe_name
+    return rf"\\.\pipe\{pipe_name}"
+
+
+PIPE_NAME = _normalize_pipe_name(os.getenv("CE_MCP_PIPE_NAME"))
+MCP_SERVER_NAME = os.getenv("CE_MCP_SERVER_NAME", "cheatengine")
 
 # ============================================================================
 # PIPE CLIENT
 # ============================================================================
 
+# Timeout in milliseconds for CE to respond (120s for heavy ops like find_call_references)
+CE_READ_TIMEOUT_MS = max(1000, _read_int_env("CE_MCP_TIMEOUT_MS", 120000))
+CE_CONNECT_WAIT_MS = max(100, _read_int_env("CE_MCP_CONNECT_WAIT_MS", 3000))
+CE_CONNECT_RETRIES = max(1, _read_int_env("CE_MCP_CONNECT_RETRIES", 3))
+CE_CONNECT_RETRY_DELAY_MS = max(0, _read_int_env("CE_MCP_CONNECT_RETRY_DELAY_MS", 250))
+
+
+def _resolve_local_file_path(file_path: str) -> Path:
+    if not isinstance(file_path, str) or not file_path.strip():
+        raise ValueError("file_path must be a non-empty string")
+
+    path = Path(file_path.strip()).expanduser()
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    else:
+        path = path.resolve()
+
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    if not path.is_file():
+        raise IsADirectoryError(f"Path is not a file: {path}")
+    return path
+
+
+def _read_text_file_robust(file_path: str, encoding: str = "auto") -> tuple[str, str, str]:
+    path = _resolve_local_file_path(file_path)
+    file_bytes = path.read_bytes()
+
+    if encoding and encoding.lower() != "auto":
+        try:
+            return file_bytes.decode(encoding), encoding, str(path)
+        except UnicodeDecodeError as exc:
+            raise UnicodeDecodeError(
+                exc.encoding,
+                exc.object,
+                exc.start,
+                exc.end,
+                f"{exc.reason}. Use encoding='auto' or provide the correct encoding."
+            ) from exc
+
+    likely_utf16 = (
+        file_bytes.startswith((b"\xff\xfe", b"\xfe\xff"))
+        or b"\x00" in file_bytes
+    )
+
+    candidates = ["utf-8-sig", "utf-8", "gb18030", "cp936"]
+    if likely_utf16:
+        candidates = ["utf-16", "utf-16-le", "utf-16-be"] + candidates
+    for candidate in candidates:
+        try:
+            return file_bytes.decode(candidate), candidate, str(path)
+        except UnicodeDecodeError:
+            continue
+
+    raise UnicodeDecodeError(
+        "unknown",
+        file_bytes,
+        0,
+        min(len(file_bytes), 1),
+        "Unable to decode file. Try passing encoding explicitly, e.g. 'utf-8' or 'gb18030'.",
+    )
+
+
+def _attach_source_metadata(result, source_path: str, source_encoding: str, source_size: int):
+    if isinstance(result, dict):
+        payload = dict(result)
+    else:
+        payload = {"success": True, "result": result}
+
+    payload["source_file"] = source_path
+    payload["source_encoding"] = source_encoding
+    payload["source_length"] = source_size
+    return payload
+
 class CEBridgeClient:
     def __init__(self):
         self.handle = None
+        self.last_connect_error = None
+        self._lock = threading.Lock()
+        self._next_request_id = 0
+
+    def _allocate_request_id(self):
+        self._next_request_id += 1
+        return self._next_request_id
 
     def connect(self):
-        """Attempts to connect to the CE Named Pipe."""
-        try:
-            self.handle = win32file.CreateFile(
-                PIPE_NAME,
-                win32file.GENERIC_READ | win32file.GENERIC_WRITE,
-                0,
-                None,
-                win32file.OPEN_EXISTING,
-                0,
-                None
-            )
-            return True
-        except pywintypes.error as e:
-            # sys.stderr.write(f"[CEBridge] Connect Error: {e}\n")
-            return False
-
-    def send_command(self, method, params=None):
-        """Send command to CE Bridge with auto-reconnection on failure."""
-        max_retries = 2
-        last_error = None
-        
-        for attempt in range(max_retries):
-            if not self.handle:
-                if not self.connect():
-                    raise ConnectionError("Cheat Engine Bridge (v11/v99) is not running (Pipe not found).")
-
-            request = {
-                "jsonrpc": "2.0",
-                "method": method,
-                "params": params or {},
-                "id": int(time.time() * 1000)
-            }
-            
+        """Attempts to connect to the CE Named Pipe (overlapped mode for timeout support)."""
+        self.last_connect_error = None
+        for attempt in range(1, CE_CONNECT_RETRIES + 1):
             try:
-                req_json = json.dumps(request).encode('utf-8')
-                header = struct.pack('<I', len(req_json))
-                
-                win32file.WriteFile(self.handle, header)
-                win32file.WriteFile(self.handle, req_json)
-                
-                resp_header_buffer = win32file.ReadFile(self.handle, 4)[1]
-                if len(resp_header_buffer) < 4:
-                    self.close()
-                    last_error = ConnectionError("Incomplete response header from CE.")
-                    continue  # Retry
-                    
-                resp_len = struct.unpack('<I', resp_header_buffer)[0]
-                
-                if resp_len > 16 * 1024 * 1024: 
-                    self.close()
-                    raise ConnectionError(f"Response too large: {resp_len} bytes")
+                win32pipe.WaitNamedPipe(PIPE_NAME, CE_CONNECT_WAIT_MS)
+            except pywintypes.error as e:
+                self.last_connect_error = (
+                    f"WaitNamedPipe failed on attempt {attempt}/{CE_CONNECT_RETRIES}: {e}"
+                )
+                if attempt < CE_CONNECT_RETRIES and CE_CONNECT_RETRY_DELAY_MS > 0:
+                    time.sleep(CE_CONNECT_RETRY_DELAY_MS / 1000.0)
+                continue
 
-                resp_body_buffer = win32file.ReadFile(self.handle, resp_len)[1]
+            try:
+                self.handle = win32file.CreateFile(
+                    PIPE_NAME,
+                    win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+                    0,
+                    None,
+                    win32file.OPEN_EXISTING,
+                    win32con.FILE_FLAG_OVERLAPPED,
+                    None
+                )
+                return True
+            except pywintypes.error as e:
+                self.last_connect_error = (
+                    f"CreateFile failed on attempt {attempt}/{CE_CONNECT_RETRIES}: {e}"
+                )
+                if attempt < CE_CONNECT_RETRIES and CE_CONNECT_RETRY_DELAY_MS > 0:
+                    time.sleep(CE_CONNECT_RETRY_DELAY_MS / 1000.0)
+
+        return False
+
+    def _write(self, data, timeout_ms=None):
+        """Overlapped write to pipe."""
+        t = timeout_ms if timeout_ms is not None else CE_READ_TIMEOUT_MS
+        overlapped = pywintypes.OVERLAPPED()
+        overlapped.hEvent = win32event.CreateEvent(None, True, False, None)
+        try:
+            win32file.WriteFile(self.handle, data, overlapped)
+            rc = win32event.WaitForSingleObject(overlapped.hEvent, t)
+            if rc == win32con.WAIT_TIMEOUT:
+                win32file.CancelIo(self.handle)
+                raise TimeoutError("Write to CE timed out")
+        finally:
+            win32api.CloseHandle(overlapped.hEvent)
+
+    def _read(self, size, timeout_ms=None):
+        """Overlapped read from pipe with timeout."""
+        t = timeout_ms if timeout_ms is not None else CE_READ_TIMEOUT_MS
+        buf = win32file.AllocateReadBuffer(size)
+        overlapped = pywintypes.OVERLAPPED()
+        overlapped.hEvent = win32event.CreateEvent(None, True, False, None)
+        try:
+            win32file.ReadFile(self.handle, buf, overlapped)
+            rc = win32event.WaitForSingleObject(overlapped.hEvent, t)
+            if rc == win32con.WAIT_TIMEOUT:
+                win32file.CancelIo(self.handle)
+                raise TimeoutError(f"CE did not respond within {t//1000}s (CE main thread may be busy)")
+            n = win32file.GetOverlappedResult(self.handle, overlapped, False)
+            return bytes(buf[:n])
+        finally:
+            win32api.CloseHandle(overlapped.hEvent)
+
+    def send_command(self, method, params=None, timeout_ms=None, max_retries=2):
+        """Send command to CE Bridge with auto-reconnection on failure."""
+        with self._lock:
+            last_error = None
+            
+            for attempt in range(max_retries):
+                if not self.handle:
+                    if not self.connect():
+                        error_text = self.last_connect_error or "unknown error"
+                        raise ConnectionError(
+                            f"Cheat Engine Bridge is not reachable on {PIPE_NAME} "
+                            f"(waited {CE_CONNECT_WAIT_MS} ms x {CE_CONNECT_RETRIES} attempts, error: {error_text})"
+                        )
+
+                request_id = self._allocate_request_id()
+                request = {
+                    "jsonrpc": "2.0",
+                    "method": method,
+                    "params": params or {},
+                    "id": request_id
+                }
                 
                 try:
-                    response = json.loads(resp_body_buffer.decode('utf-8'))
-                except json.JSONDecodeError:
-                    self.close()
-                    last_error = ConnectionError("Invalid JSON received from CE")
-                    continue  # Retry
-                
-                if 'error' in response:
-                    return {"success": False, "error": str(response['error'])}
-                if 'result' in response:
-                    return response['result']
+                    req_json = json.dumps(request).encode('utf-8')
+                    header = struct.pack('<I', len(req_json))
                     
-                return response
+                    self._write(header, timeout_ms=timeout_ms)
+                    self._write(req_json, timeout_ms=timeout_ms)
+                    
+                    resp_header_buffer = self._read(4, timeout_ms=timeout_ms)
+                    if len(resp_header_buffer) < 4:
+                        self.close()
+                        last_error = ConnectionError("Incomplete response header from CE.")
+                        continue
+                        
+                    resp_len = struct.unpack('<I', resp_header_buffer)[0]
+                    
+                    if resp_len > 16 * 1024 * 1024:
+                        self.close()
+                        last_error = ConnectionError(f"Response too large: {resp_len} bytes")
+                        continue
 
-            except pywintypes.error as e:
-                self.close()
-                last_error = ConnectionError(f"Pipe Communication failed: {e}")
-                if attempt < max_retries - 1:
-                    continue  # Retry
-        
-        # All retries failed
-        if last_error:
-            raise last_error
-        raise ConnectionError("Unknown communication error")
+                    resp_body_buffer = self._read(resp_len, timeout_ms=timeout_ms)
+                    if len(resp_body_buffer) < resp_len:
+                        self.close()
+                        last_error = ConnectionError("Incomplete response body from CE.")
+                        continue
+                    
+                    try:
+                        response = json.loads(resp_body_buffer.decode('utf-8'))
+                    except json.JSONDecodeError:
+                        self.close()
+                        last_error = ConnectionError("Invalid JSON received from CE")
+                        continue
+
+                    if response.get("id") not in (None, request_id):
+                        self.close()
+                        last_error = ConnectionError(
+                            f"Mismatched response id from CE (expected {request_id}, got {response.get('id')})"
+                        )
+                        continue
+                    
+                    if 'error' in response and response['error']:
+                        error = response['error']
+                        if isinstance(error, dict):
+                            return {
+                                "success": False,
+                                "error": error.get("message", "Unknown CE error"),
+                                "error_code": error.get("code"),
+                                "error_data": error.get("data"),
+                            }
+                        return {"success": False, "error": str(error)}
+                    if 'result' in response:
+                        return response['result']
+                    
+                    return response
+
+                except (pywintypes.error, TimeoutError) as e:
+                    self.close()
+                    last_error = ConnectionError(f"Pipe Communication failed: {e}")
+                    if attempt < max_retries - 1:
+                        continue
+            
+            if last_error:
+                raise last_error
+            raise ConnectionError("Unknown communication error")
 
     def close(self):
         if self.handle:
@@ -293,12 +473,10 @@ def read_string(address: str, max_length: int = 256, wide: bool = False) -> str:
 
 @mcp.tool()
 def read_pointer(address: str, offsets: list[int] = None) -> str:
-    """Read a pointer chain. Returns the final address and value."""
-    # V11 supports 'read_pointer' command for simple dereference or 'read_pointer_chain' for multiple
+    """Read one pointer at address, or follow a pointer chain if offsets are provided."""
     if offsets:
         return format_result(ce_client.send_command("read_pointer_chain", {"base": address, "offsets": offsets}))
-    else:
-        return format_result(ce_client.send_command("read_pointer_chain", {"base": address, "offsets": [0]}))
+    return format_result(ce_client.send_command("read_pointer", {"address": address}))
 
 @mcp.tool()
 def read_pointer_chain(base: str, offsets: list[int]) -> str:
@@ -313,8 +491,8 @@ def checksum_memory(address: str, size: int) -> str:
 # --- SCANNING ---
 
 @mcp.tool()
-def scan_all(value: str, type: str = "exact", protection: str = "+W-C") -> str:
-    """Unified Memory Scanner. Types: exact, string, array. Protection: +W-C (Writable, Not Copy-on-Write)."""
+def scan_all(value: str | int | float, type: str = "dword", protection: str = "+W-C") -> str:
+    """Unified memory scanner. Types: byte, word, dword, qword, float, double, string. Protection default: +W-C."""
     return format_result(ce_client.send_command("scan_all", {"value": value, "type": type, "protection": protection}))
 
 @mcp.tool()
@@ -322,12 +500,12 @@ def get_scan_results(max: int = 100) -> str:
     """Get results from the last 'scan_all' operation. Use 'max' to limit output."""
     return format_result(ce_client.send_command("get_scan_results", {"max": max}))
 @mcp.tool()
-def next_scan(value: str, scan_type: str = "exact") -> str:
+def next_scan(value: str | int | float, scan_type: str = "exact") -> str:
     """Next scan to filter results. Types: exact, increased, decreased, changed, unchanged, bigger, smaller."""
     return format_result(ce_client.send_command("next_scan", {"value": value, "scan_type": scan_type}))
 
 @mcp.tool()
-def write_integer(address: str, value: int, type: str = "dword") -> str:
+def write_integer(address: str, value: int | float, type: str = "dword") -> str:
     """Write a number to memory. Types: byte, word, dword, qword, float, double."""
     return format_result(ce_client.send_command("write_integer", {"address": address, "value": value, "type": type}))
 
@@ -395,9 +573,9 @@ def find_references(address: str, limit: int = 50) -> str:
     return format_result(ce_client.send_command("find_references", {"address": address, "limit": limit}))
 
 @mcp.tool()
-def find_call_references(function_address: str, limit: int = 100) -> str:
-    """Find all locations that CALL this function."""
-    return format_result(ce_client.send_command("find_call_references", {"address": function_address, "limit": limit}))
+def find_call_references(function_address: str, limit: int = 100, timeout_ms: int = 30000) -> str:
+    """Find all locations that CALL this function. WARNING: heavy scan, may be slow on large processes. timeout_ms controls how long to wait (default 30s); increase if needed. No retry on timeout to avoid freezing CE."""
+    return format_result(ce_client.send_command("find_call_references", {"address": function_address, "limit": limit}, timeout_ms=timeout_ms, max_retries=1))
 
 @mcp.tool()
 def dissect_structure(address: str, size: int = 256) -> str:
@@ -465,24 +643,39 @@ def stop_dbvm_watch(address: str) -> str:
     return format_result(ce_client.send_command("stop_dbvm_watch", {"address": address}))
 
 @mcp.tool()
-def poll_dbvm_watch(address: str, max_results: int = 1000) -> str:
-    """Poll DBVM watch logs WITHOUT stopping. Returns register state at each execution hit."""
+def poll_dbvm_watch(address: str, max_results: int = 1000, clear: bool = True) -> str:
+    """Poll DBVM watch logs WITHOUT stopping. Set clear=False to request sticky logs between polls."""
     return format_result(ce_client.send_command("poll_dbvm_watch", {
         "address": address, 
-        "max_results": max_results
+        "max_results": max_results,
+        "clear": clear
     }))
 
 # --- SCRIPTING & CONTROL ---
 
 @mcp.tool()
-def evaluate_lua(code: str) -> str:
-    """Execute arbitrary Lua code in Cheat Engine."""
-    return format_result(ce_client.send_command("evaluate_lua", {"code": code}))
+def evaluate_lua(code: str, structured: bool = False) -> str:
+    """Execute arbitrary Lua code in Cheat Engine. Set structured=True to preserve table results."""
+    return format_result(ce_client.send_command("evaluate_lua", {"code": code, "serialize_result": structured}))
 
 @mcp.tool()
 def auto_assemble(script: str) -> str:
     """Run an AutoAssembler script (injection, code caves, etc)."""
     return format_result(ce_client.send_command("auto_assemble", {"script": script}))
+
+@mcp.tool()
+def evaluate_lua_file(file_path: str, encoding: str = "auto", structured: bool = False) -> str:
+    """Load Lua code from a local file and execute it in Cheat Engine."""
+    code, used_encoding, resolved_path = _read_text_file_robust(file_path, encoding)
+    result = ce_client.send_command("evaluate_lua", {"code": code, "serialize_result": structured})
+    return format_result(_attach_source_metadata(result, resolved_path, used_encoding, len(code)))
+
+@mcp.tool()
+def auto_assemble_file(file_path: str, encoding: str = "auto") -> str:
+    """Load an AutoAssembler script from a local file and execute it."""
+    script, used_encoding, resolved_path = _read_text_file_robust(file_path, encoding)
+    result = ce_client.send_command("auto_assemble", {"script": script})
+    return format_result(_attach_source_metadata(result, resolved_path, used_encoding, len(script)))
 
 @mcp.tool()
 def ping() -> str:

--- a/MCP_Server/test_mcp.py
+++ b/MCP_Server/test_mcp.py
@@ -19,9 +19,23 @@ import struct
 import json
 import time
 import sys
+import os
+import tempfile
+from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, List, Callable
 
-PIPE_NAME = r"\\.\pipe\CE_MCP_Bridge_v99"
+DEFAULT_PIPE_NAME = "CE_MCP_Bridge_v99"
+
+
+def normalize_pipe_name(pipe_name: str | None) -> str:
+    raw_name = pipe_name or os.getenv("CE_MCP_PIPE_NAME") or DEFAULT_PIPE_NAME
+    if raw_name.startswith("\\\\.\\pipe\\"):
+        return raw_name
+    return rf"\\.\pipe\{raw_name}"
+
+
+PIPE_NAME = normalize_pipe_name(None)
+CONNECT_WAIT_MS = int(os.getenv("CE_MCP_CONNECT_WAIT_MS", "3000"))
 
 class TestResult:
     PASSED = "PASSED"
@@ -35,6 +49,7 @@ class MCPTestClient:
         
     def connect(self) -> bool:
         try:
+            win32pipe.WaitNamedPipe(PIPE_NAME, CONNECT_WAIT_MS)
             self.handle = win32file.CreateFile(
                 PIPE_NAME,
                 win32file.GENERIC_READ | win32file.GENERIC_WRITE,
@@ -72,7 +87,34 @@ class MCPTestClient:
     
     def close(self):
         if self.handle:
-            win32file.CloseHandle(self.handle)
+            try:
+                win32file.CloseHandle(self.handle)
+            finally:
+                self.handle = None
+
+
+class PythonToolClient:
+    """Invoke Python MCP helper functions directly for wrapper-level smoke tests."""
+
+    def __init__(self):
+        import mcp_cheatengine as python_server
+
+        self.python_server = python_server
+        self.tool_map = {
+            "evaluate_lua_file": python_server.evaluate_lua_file,
+            "auto_assemble_file": python_server.auto_assemble_file,
+        }
+
+    def send_command(self, method: str, params: Optional[dict] = None) -> dict:
+        if params is None:
+            params = {}
+
+        if method not in self.tool_map:
+            raise ValueError(f"Unsupported Python helper method: {method}")
+
+        result = self.tool_map[method](**params)
+        payload = json.loads(result) if isinstance(result, str) else result
+        return {"result": payload}
 
 
 # ============================================================================
@@ -379,9 +421,27 @@ def main():
                       f"Expected 'true' or 'false', got '{r.get('result')}'"),
         ]
     )
+
+    all_tests["evaluate_lua_structured"] = TestCase(
+        "Evaluate Lua (structured table)", "evaluate_lua",
+        params={"code": 'return { answer = 42, label = "ok" }', "serialize_result": True},
+        validators=[
+            has_field("success", bool),
+            field_equals("success", True),
+            has_field("result", dict),
+            has_field("result_type", str),
+            field_equals("result_type", "table"),
+            has_field("serialized", bool),
+            field_equals("serialized", True),
+            lambda r: (r.get("result", {}).get("answer") == 42,
+                      f"Expected result.answer=42, got {r.get('result')}"),
+            lambda r: (r.get("result", {}).get("label") == "ok",
+                      f"Expected result.label='ok', got {r.get('result')}"),
+        ]
+    )
     
     # Run Category 1
-    for test in ["ping", "get_process_info", "evaluate_lua_simple", "evaluate_lua_complex", "evaluate_lua_targetIs64Bit"]:
+    for test in ["ping", "get_process_info", "evaluate_lua_simple", "evaluate_lua_complex", "evaluate_lua_targetIs64Bit", "evaluate_lua_structured"]:
         all_tests[test].run(client)
     
     # Get arch info for later tests
@@ -404,6 +464,17 @@ def main():
             field_equals("success", True),
             has_field("count", int),
             field_in_range("count", 1, 100000000),  # At least 1 result expected
+        ]
+    )
+
+    all_tests["scan_all_default_type"] = TestCase(
+        "Scan All (default dword type)", "scan_all",
+        params={"value": 1},
+        validators=[
+            has_field("success", bool),
+            field_equals("success", True),
+            has_field("count", int),
+            field_in_range("count", 1, 100000000),
         ]
     )
     
@@ -440,7 +511,7 @@ def main():
     )
     
     # Run Category 2
-    for test in ["scan_all", "get_scan_results", "aob_scan", "search_string"]:
+    for test in ["scan_all", "scan_all_default_type", "get_scan_results", "aob_scan", "search_string"]:
         all_tests[test].run(client)
     
     # =========================================================================
@@ -763,6 +834,26 @@ def main():
             field_is_hex_address("final_address"),
         ]
     )
+
+    all_tests["read_pointer"] = TestCase(
+        "Read Pointer (simple dereference)", "read_pointer",
+        params={"address": hex(module_base)},
+        validators=[
+            has_field("success", bool),
+            field_equals("success", True),
+            has_field("base", str),
+            has_field("final_address", str),
+            has_field("path", list),
+            field_is_hex_address("base"),
+            field_is_hex_address("final_address"),
+            lambda r: (len(r.get("path", [])) == 1,
+                      f"Expected simple read_pointer path length 1, got {len(r.get('path', []))}"),
+            lambda r: (r.get("path", [None])[0] == r.get("base"),
+                      f"Expected path[0] to equal base, got {r.get('path')} vs {r.get('base')}"),
+            lambda r: (int(r.get("final_address", "0"), 16) == module_base,
+                      f"Expected final_address to stay at base {hex(module_base)}, got {r.get('final_address')}"),
+        ]
+    )
     
     all_tests["auto_assemble"] = TestCase(
         "Auto Assemble (safe alloc)", "auto_assemble",
@@ -812,7 +903,7 @@ def main():
     
     # Run Category 8
     for test in ["get_thread_list", "enum_memory_regions_full", "dissect_structure", 
-                 "read_pointer_chain", "auto_assemble", "get_rtti_classname", 
+                 "read_pointer", "read_pointer_chain", "auto_assemble", "get_rtti_classname", 
                  "get_address_info", "checksum_memory", "generate_signature"]:
         all_tests[test].run(client)
     
@@ -864,6 +955,19 @@ def main():
         )
         
         all_tests["start_dbvm_watch"].run(client)
+
+        all_tests["poll_dbvm_watch"] = TestCase(
+            "Poll DBVM Watch (clear=false)", "poll_dbvm_watch",
+            params={"address": dbvm_test_addr, "max_results": 1, "clear": False},
+            validators=[
+                has_field("success", bool),
+                has_field("clear_requested", bool),
+                field_equals("clear_requested", False),
+                has_field("hits", list),
+            ]
+        )
+
+        all_tests["poll_dbvm_watch"].run(client)
         
         # Always run stop to clean up, whether start succeeded or not
         all_tests["stop_dbvm_watch"] = TestCase(
@@ -885,6 +989,12 @@ def main():
             params={"address": hex(module_base), "mode": "w"},
             skip_reason="DBVM not loaded (get_physical_address failed)"
         )
+
+        all_tests["poll_dbvm_watch"] = TestCase(
+            "Poll DBVM Watch", "poll_dbvm_watch",
+            params={"address": hex(module_base), "max_results": 1, "clear": False},
+            skip_reason="DBVM not loaded (no active watch)"
+        )
         
         all_tests["stop_dbvm_watch"] = TestCase(
             "Stop DBVM Watch", "stop_dbvm_watch",
@@ -893,7 +1003,75 @@ def main():
         )
         
         all_tests["start_dbvm_watch"].run(client)
+        all_tests["poll_dbvm_watch"].run(client)
         all_tests["stop_dbvm_watch"].run(client)
+
+    client.close()
+
+    # =========================================================================
+    # CATEGORY 10: Python MCP Wrapper Helpers
+    # =========================================================================
+    print("\n" + "=" * 70)
+    print("CATEGORY 10: Python MCP Wrapper Helpers")
+    print("=" * 70)
+
+    python_tool_skip_reason = None
+    try:
+        python_tool_client = PythonToolClient()
+    except Exception as exc:
+        python_tool_client = None
+        python_tool_skip_reason = f"Could not import or initialize Python MCP wrapper: {exc}"
+
+    with tempfile.TemporaryDirectory(prefix="mcp_bridge_tests_") as temp_dir:
+        temp_path = Path(temp_dir)
+        lua_file = temp_path / "临时脚本.lua"
+        aa_file = temp_path / "临时补丁.cea"
+        lua_file.write_text('return { answer = 42, label = "ok" }\n', encoding="utf-8")
+        aa_file.write_text("globalalloc(mcp_test_region_file_v3,4)\n", encoding="utf-8")
+
+        all_tests["evaluate_lua_file"] = TestCase(
+            "Evaluate Lua File (UTF-8 + Chinese path)", "evaluate_lua_file",
+            params={"file_path": str(lua_file), "structured": True},
+            validators=[
+                has_field("success", bool),
+                field_equals("success", True),
+                has_field("result", dict),
+                has_field("serialized", bool),
+                field_equals("serialized", True),
+                has_field("source_file", str),
+                has_field("source_encoding", str),
+                has_field("source_length", int),
+                lambda r: (Path(r.get("source_file", "")).name == lua_file.name,
+                          f"Expected source_file to end with {lua_file.name}, got {r.get('source_file')}"),
+                lambda r: (r.get("result", {}).get("answer") == 42,
+                          f"Expected result.answer=42, got {r.get('result')}"),
+            ],
+            skip_reason=python_tool_skip_reason
+        )
+
+        all_tests["auto_assemble_file"] = TestCase(
+            "Auto Assemble File (UTF-8 + Chinese path)", "auto_assemble_file",
+            params={"file_path": str(aa_file)},
+            validators=[
+                has_field("success", bool),
+                field_equals("success", True),
+                has_field("executed", bool),
+                field_equals("executed", True),
+                has_field("source_file", str),
+                has_field("source_encoding", str),
+                has_field("source_length", int),
+                lambda r: (Path(r.get("source_file", "")).name == aa_file.name,
+                          f"Expected source_file to end with {aa_file.name}, got {r.get('source_file')}"),
+            ],
+            skip_reason=python_tool_skip_reason
+        )
+
+        if python_tool_client:
+            for test in ["evaluate_lua_file", "auto_assemble_file"]:
+                all_tests[test].run(python_tool_client)
+        else:
+            all_tests["evaluate_lua_file"].run(client)
+            all_tests["auto_assemble_file"].run(client)
     
     # =========================================================================
     # SUMMARY
@@ -908,16 +1086,17 @@ def main():
     total = len(all_tests)
     
     categories = {
-        "Basic & Utility": ["ping", "get_process_info", "evaluate_lua_simple", "evaluate_lua_complex", "evaluate_lua_targetIs64Bit"],
-        "Scanning": ["scan_all", "get_scan_results", "aob_scan", "search_string"],
+        "Basic & Utility": ["ping", "get_process_info", "evaluate_lua_simple", "evaluate_lua_complex", "evaluate_lua_targetIs64Bit", "evaluate_lua_structured"],
+        "Scanning": ["scan_all", "scan_all_default_type", "get_scan_results", "aob_scan", "search_string"],
         "Memory Reading": ["read_memory", "read_integer_byte", "read_integer_word", "read_integer_dword", "read_string"],
         "Disassembly": ["disassemble", "get_instruction_info", "find_function_boundaries", "analyze_function"],
         "References": ["find_references", "find_call_references"],
         "Breakpoints": ["list_breakpoints", "clear_all_breakpoints"],
         "Modules": ["enum_modules", "get_symbol_address", "get_memory_regions"],
-        "High-Level": ["get_thread_list", "enum_memory_regions_full", "dissect_structure", "read_pointer_chain", 
+        "High-Level": ["get_thread_list", "enum_memory_regions_full", "dissect_structure", "read_pointer", "read_pointer_chain", 
                       "auto_assemble", "get_rtti_classname", "get_address_info", "checksum_memory", "generate_signature"],
-        "DBVM": ["get_physical_address", "start_dbvm_watch", "stop_dbvm_watch"],
+        "DBVM": ["get_physical_address", "start_dbvm_watch", "poll_dbvm_watch", "stop_dbvm_watch"],
+        "Python Wrapper": ["evaluate_lua_file", "auto_assemble_file"],
     }
     
     for cat_name, tests in categories.items():

--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ Add to your MCP configuration (e.g., `mcp_config.json`):
 ```
 Restart the IDE to load the MCP server config.
 
+### Optional Environment Overrides
+If you run multiple bridge instances or need longer startup windows, the Python side now honors these environment variables:
+
+```powershell
+$env:CE_MCP_PIPE_NAME="CE_MCP_Bridge_v99"
+$env:CE_MCP_SERVER_NAME="cheatengine"
+$env:CE_MCP_TIMEOUT_MS="120000"
+$env:CE_MCP_CONNECT_WAIT_MS="3000"
+$env:CE_MCP_CONNECT_RETRIES="3"
+$env:CE_MCP_CONNECT_RETRY_DELAY_MS="250"
+```
+
+- `CE_MCP_PIPE_NAME`: short pipe name or full `\\.\pipe\...` path
+- `CE_MCP_SERVER_NAME`: override the FastMCP server name exposed to your IDE
+- `CE_MCP_TIMEOUT_MS`: response timeout for long CE operations
+- `CE_MCP_CONNECT_WAIT_MS`: how long the MCP server waits for the pipe to appear
+- `CE_MCP_CONNECT_RETRIES`: how many times the Python side retries pipe connection
+- `CE_MCP_CONNECT_RETRY_DELAY_MS`: delay between connection retries
+
 ### 3. Verify Connection
 Use the `ping` tool to verify connectivity:
 ```json
@@ -127,11 +146,25 @@ Use the `ping` tool to verify connectivity:
 "What process is attached?"
 "Read 16 bytes at the base address"
 "Disassemble the entry point"
+"Run my local Lua helper with evaluate_lua_file"
+"Apply my local AutoAssembler patch with auto_assemble_file"
 ```
+
+### 5. Run Local Files Through MCP
+You can now execute local script files directly from the Python MCP layer without copy-pasting them into chat:
+
+```text
+evaluate_lua_file(file_path="C:/path/to/helper.lua", structured=true)
+auto_assemble_file(file_path="C:/path/to/patch.cea")
+```
+
+- `evaluate_lua_file` auto-detects common encodings including UTF-8 and GB-family encodings
+- `auto_assemble_file` is useful for local `.CEA` / AutoAssembler payloads
+- Both tools return `source_file`, `source_encoding`, and `source_length` metadata for traceability
 
 ---
 
-## 43 MCP Tools Available
+## 45 MCP Tools Available
 
 ### Memory
 | Tool | Description |
@@ -152,7 +185,7 @@ Use the `ping` tool to verify connectivity:
 | Tool | Description |
 |------|-------------|
 | `set_breakpoint`, `set_data_breakpoint` | Hardware breakpoints |
-| `start_dbvm_watch` | Ring -1 invisible tracing |
+| `start_dbvm_watch`, `poll_dbvm_watch`, `stop_dbvm_watch` | Ring -1 invisible tracing |
 
 And many more at `AI_Context/MCP_Bridge_Command_Reference.md`
 
@@ -209,6 +242,12 @@ Running the test:
 ```bash
 python MCP_Server/test_mcp.py
 ```
+
+The suite now also covers:
+- `scan_all` default `dword` behavior
+- direct `read_pointer` semantics
+- structured Lua evaluation
+- Python helper tools such as `evaluate_lua_file` and `auto_assemble_file`
 
 Expected output:
 ```


### PR DESCRIPTION
## Summary

This PR improves MCP bridge reliability and adds file-based helper tools for local Cheat Engine workflows.

## What changed

### Python MCP layer

- Harden named-pipe connection handling with configurable environment variables, wait/retry logic, and clearer connection errors
- Add `evaluate_lua_file` and `auto_assemble_file` so local Lua / Auto Assembler files can be executed directly
- Fix `read_pointer` so simple dereference uses the correct Lua handler
- Expose `poll_dbvm_watch(clear=...)` from the Python tool layer
- Align `scan_all` defaults/docs with actual behavior by making `dword` the default type

### CE Lua bridge

- Add scan object cleanup to reduce resource leakage across repeated scans
- Fix breakpoint slot tracking so repeated breakpoint updates do not leak hardware slots
- Protect `PipeWorker` read/write paths against disconnects and malformed payloads
- Extend `evaluate_lua` to optionally return structured results

### Docs and tests

- Update README with environment variable configuration and local file execution examples
- Extend test coverage for:
  - structured Lua evaluation
  - default `scan_all` behavior
  - direct `read_pointer` semantics
  - `poll_dbvm_watch(clear=False)`
  - file-based helper tools

## Why

These changes make the bridge more stable in long-running sessions and make it easier to run local helper scripts without copy-pasting code into chat.

## Testing

Validated with:

- `python -m py_compile MCP_Server/mcp_cheatengine.py MCP_Server/test_mcp.py`