### PR TITLE
feat(unit-07): process lifecycle tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,109 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-07 Process Lifecycle <<<
+
+local function cmd_open_process(params)
+    local target = params.process_id_or_name
+    if not target then return { success = false, error = "Missing process_id_or_name" } end
+
+    local numeric = tonumber(target)
+    local ok, err = pcall(openProcess, numeric or target)
+    if not ok then return { success = false, error = tostring(err) } end
+
+    local ok2, pid = pcall(getOpenedProcessID)
+    if not ok2 or not pid or pid == 0 then
+        return { success = false, error = "Process not found or could not be opened" }
+    end
+
+    local name = (process ~= "" and process) or tostring(target)
+    return { success = true, process_id = pid, process_name = name }
+end
+
+local function cmd_get_process_list(params)
+    local ok, list = pcall(getProcesslist)
+    if not ok then return { success = false, error = tostring(list) } end
+
+    local processes = {}
+    if list then
+        for k, v in pairs(list) do
+            local pid, name
+            if type(k) == "number" and type(v) == "string" then
+                pid = k
+                name = v
+            elseif type(v) == "string" then
+                local hex_pid, pname = v:match("^(%x+)-(.+)$")
+                if hex_pid then
+                    pid = tonumber(hex_pid, 16)
+                    name = pname
+                end
+            end
+            if pid and name then
+                table.insert(processes, { pid = pid, name = name })
+            end
+        end
+    end
+
+    return { success = true, count = #processes, processes = processes }
+end
+
+local function cmd_get_processid_from_name(params)
+    local name = params.name
+    if not name then return { success = false, error = "Missing name" } end
+
+    local ok, pid = pcall(getProcessIDFromProcessName, name)
+    if not ok then return { success = false, error = tostring(pid) } end
+    if not pid or pid == 0 then
+        return { success = false, error = "Process not found", error_code = "NOT_FOUND" }
+    end
+
+    return { success = true, process_id = pid }
+end
+
+local function cmd_get_foreground_process(params)
+    local ok, pid = pcall(getForegroundProcess)
+    if not ok then return { success = false, error = tostring(pid) } end
+
+    local hwnd = 0
+    local ok2, wh = pcall(getForegroundWindow)
+    if ok2 and wh then hwnd = wh end
+
+    return { success = true, process_id = pid or 0, window_handle = toHex(hwnd) }
+end
+
+local function cmd_create_process(params)
+    local path = params.path
+    if not path then return { success = false, error = "Missing path" } end
+    local args = params.args or ""
+    local debug_flag = params.debug or false
+    local break_on_entry = params.break_on_entry or false
+
+    local ok, err = pcall(createProcess, path, args, debug_flag, break_on_entry)
+    if not ok then return { success = false, error = tostring(err) } end
+
+    local ok2, pid = pcall(getOpenedProcessID)
+    local result_pid = (ok2 and pid) or 0
+
+    return { success = true, process_id = result_pid }
+end
+
+local function cmd_get_opened_process_id(params)
+    local ok, pid = pcall(getOpenedProcessID)
+    if not ok then return { success = false, error = tostring(pid) } end
+    if not pid or pid == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+    return { success = true, process_id = pid }
+end
+
+local function cmd_get_opened_process_handle(params)
+    local ok, handle = pcall(getOpenedProcessHandle)
+    if not ok then return { success = false, error = tostring(handle) } end
+    return { success = true, handle = toHex(handle or 0) }
+end
+
+-- >>> END UNIT-07 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2063,6 +2166,16 @@ local commandHandlers = {
     get_process_info = cmd_get_process_info,
     enum_modules = cmd_enum_modules,
     get_symbol_address = cmd_get_symbol_address,
+
+    -- >>> BEGIN UNIT-07 Process Lifecycle <<<
+    open_process = cmd_open_process,
+    get_process_list = cmd_get_process_list,
+    get_processid_from_name = cmd_get_processid_from_name,
+    get_foreground_process = cmd_get_foreground_process,
+    create_process = cmd_create_process,
+    get_opened_process_id = cmd_get_opened_process_id,
+    get_opened_process_handle = cmd_get_opened_process_handle,
+    -- >>> END UNIT-07 <<<
     
     -- Memory Read
     read_memory = cmd_read_memory,

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,90 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# >>> BEGIN UNIT-07 Process Lifecycle <<<
+
+@mcp.tool()
+def open_process(process_id_or_name: str) -> str:
+    """Open a process by PID or name and attach Cheat Engine to it.
+
+    Args:
+        process_id_or_name: Numeric PID as string (e.g. "12345") or process name (e.g. "notepad.exe").
+
+    Returns:
+        JSON with {success, process_id, process_name}.
+    """
+    return format_result(ce_client.send_command("open_process", {"process_id_or_name": process_id_or_name}))
+
+@mcp.tool()
+def get_process_list() -> str:
+    """Get the list of running processes on the system.
+
+    Returns:
+        JSON with {success, count, processes: [{pid: int, name: str}, ...]}.
+    """
+    return format_result(ce_client.send_command("get_process_list"))
+
+@mcp.tool()
+def get_processid_from_name(name: str) -> str:
+    """Look up the PID of a process by its executable name.
+
+    Args:
+        name: Process name to search for (e.g. "notepad.exe").
+
+    Returns:
+        JSON with {success, process_id} or {success=false, error, error_code="NOT_FOUND"}.
+    """
+    return format_result(ce_client.send_command("get_processid_from_name", {"name": name}))
+
+@mcp.tool()
+def get_foreground_process() -> str:
+    """Get the PID and window handle of the process currently in the foreground.
+
+    Returns:
+        JSON with {success, process_id, window_handle}.
+    """
+    return format_result(ce_client.send_command("get_foreground_process"))
+
+@mcp.tool()
+def create_process(path: str, args: str = "", debug: bool = False, break_on_entry: bool = False) -> str:
+    """Create and optionally debug a new process.
+
+    Args:
+        path: Full path to the executable.
+        args: Command-line arguments string (default empty).
+        debug: Attach Windows debugger if True.
+        break_on_entry: Break on entry point if True (requires debug=True).
+
+    Returns:
+        JSON with {success, process_id}.
+    """
+    return format_result(ce_client.send_command("create_process", {
+        "path": path,
+        "args": args,
+        "debug": debug,
+        "break_on_entry": break_on_entry,
+    }))
+
+@mcp.tool()
+def get_opened_process_id() -> str:
+    """Get the PID of the process currently attached to Cheat Engine.
+
+    Returns:
+        JSON with {success, process_id} or {success=false, error_code="NO_PROCESS"}.
+    """
+    return format_result(ce_client.send_command("get_opened_process_id"))
+
+@mcp.tool()
+def get_opened_process_handle() -> str:
+    """Get the OS handle of the process currently attached to Cheat Engine as a hex string.
+
+    Returns:
+        JSON with {success, handle} where handle is a hex string.
+    """
+    return format_result(ce_client.send_command("get_opened_process_handle"))
+
+# >>> END UNIT-07 <<<
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
7 new MCP tools for process lifecycle management:
- `open_process` — attach by PID or name.
- `get_process_list` — enumerate all running processes.
- `get_processid_from_name` — name → PID lookup.
- `get_foreground_process` — active window's process.
- `create_process` — spawn (optionally with debugger).
- `get_opened_process_id` / `get_opened_process_handle` — query current attachment.

## Unit
Unit 7 of 26.

## Testing
Static checks only — worker sandbox has no Cheat Engine instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)