### PR TITLE
feat(unit-08): memory allocation and protection tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,212 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-08 Memory Allocation <<<
+
+-- Windows PAGE_* protection constants used by allocateMemory
+local PROT_CONSTANTS = {
+    r   = 0x02,  -- PAGE_READONLY
+    rw  = 0x04,  -- PAGE_READWRITE
+    rx  = 0x20,  -- PAGE_EXECUTE_READ
+    rwx = 0x40,  -- PAGE_EXECUTE_READWRITE
+}
+
+-- Reconstruct a PAGE_* name string from r/w/x booleans
+local function protectionName(r, w, x)
+    if x and w and r then return "PAGE_EXECUTE_READWRITE" end
+    if x and r        then return "PAGE_EXECUTE_READ"      end
+    if w and r        then return "PAGE_READWRITE"         end
+    if r              then return "PAGE_READONLY"          end
+    if x              then return "PAGE_EXECUTE"           end
+    if w              then return "PAGE_WRITECOPY"         end
+    return "PAGE_NOACCESS"
+end
+
+local function cmd_allocate_memory(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+
+    local size = params.size
+    if not size or type(size) ~= "number" or size <= 0 then
+        return { success = false, error = "Invalid size parameter", error_code = "INVALID_PARAMS" }
+    end
+
+    local baseAddr = params.base_address
+    if type(baseAddr) == "string" then baseAddr = getAddressSafe(baseAddr) end
+
+    local protStr = params.protection or "rwx"
+    local protConst = PROT_CONSTANTS[protStr]
+    if not protConst then
+        return { success = false, error = "Invalid protection string; use r, rw, rx, or rwx", error_code = "INVALID_PARAMS" }
+    end
+
+    local ok, result = pcall(allocateMemory, size, baseAddr, protConst)
+    if not ok then
+        return { success = false, error = tostring(result), error_code = "OUT_OF_RESOURCES" }
+    end
+    if not result or result == 0 then
+        return { success = false, error = "Allocation returned null address", error_code = "OUT_OF_RESOURCES" }
+    end
+
+    return { success = true, address = toHex(result) }
+end
+
+local function cmd_free_memory(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr or addr == 0 then
+        return { success = false, error = "Invalid address", error_code = "INVALID_ADDRESS" }
+    end
+
+    local size = params.size or 0
+
+    local ok, err = pcall(deAlloc, addr, size)
+    if not ok then
+        return { success = false, error = tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+
+    return { success = true }
+end
+
+local function cmd_allocate_shared_memory(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+
+    local name = params.name
+    if not name or name == "" then
+        return { success = false, error = "Invalid name parameter", error_code = "INVALID_PARAMS" }
+    end
+
+    local size = params.size
+    if not size or type(size) ~= "number" or size <= 0 then
+        return { success = false, error = "Invalid size parameter", error_code = "INVALID_PARAMS" }
+    end
+
+    local ok, result = pcall(allocateSharedMemory, name, size)
+    if not ok then
+        return { success = false, error = tostring(result), error_code = "OUT_OF_RESOURCES" }
+    end
+    if not result or result == 0 then
+        return { success = false, error = "Shared memory allocation returned null address", error_code = "OUT_OF_RESOURCES" }
+    end
+
+    return { success = true, address = toHex(result) }
+end
+
+local function cmd_get_memory_protection(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr or addr == 0 then
+        return { success = false, error = "Invalid address", error_code = "INVALID_ADDRESS" }
+    end
+
+    local ok, prot = pcall(getMemoryProtection, addr)
+    if not ok or not prot then
+        return { success = false, error = tostring(prot), error_code = "INTERNAL_ERROR" }
+    end
+
+    local r = prot.r == true
+    local w = prot.w == true
+    local x = prot.x == true
+
+    return {
+        success = true,
+        read    = r,
+        write   = w,
+        execute = x,
+        raw     = protectionName(r, w, x)
+    }
+end
+
+local function cmd_set_memory_protection(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr or addr == 0 then
+        return { success = false, error = "Invalid address", error_code = "INVALID_ADDRESS" }
+    end
+
+    local size = params.size
+    if not size or type(size) ~= "number" or size <= 0 then
+        return { success = false, error = "Invalid size parameter", error_code = "INVALID_PARAMS" }
+    end
+
+    local r = params.read  ~= false
+    local w = params.write ~= false
+    local x = params.execute ~= false
+
+    local ok, err = pcall(setMemoryProtection, addr, size, { r = r, w = w, x = x })
+    if not ok then
+        return { success = false, error = tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+
+    return { success = true }
+end
+
+local function cmd_full_access(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr or addr == 0 then
+        return { success = false, error = "Invalid address", error_code = "INVALID_ADDRESS" }
+    end
+
+    local size = params.size
+    if not size or type(size) ~= "number" or size <= 0 then
+        return { success = false, error = "Invalid size parameter", error_code = "INVALID_PARAMS" }
+    end
+
+    local ok, err = pcall(fullAccess, addr, size)
+    if not ok then
+        return { success = false, error = tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+
+    return { success = true }
+end
+
+local function cmd_allocate_kernel_memory(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+
+    if not dbk_initialized() then
+        return { success = false, error = "Kernel driver (DBK) not loaded", error_code = "DBK_NOT_LOADED" }
+    end
+
+    local size = params.size
+    if not size or type(size) ~= "number" or size <= 0 then
+        return { success = false, error = "Invalid size parameter", error_code = "INVALID_PARAMS" }
+    end
+
+    local ok, result = pcall(allocateKernelMemory, size)
+    if not ok then
+        return { success = false, error = tostring(result), error_code = "OUT_OF_RESOURCES" }
+    end
+    if not result or result == 0 then
+        return { success = false, error = "Kernel allocation returned null address", error_code = "OUT_OF_RESOURCES" }
+    end
+
+    return { success = true, address = toHex(result) }
+end
+
+-- >>> END UNIT-08 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2337,16 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- >>> BEGIN UNIT-08 dispatcher entries <<<
+    allocate_memory        = cmd_allocate_memory,
+    free_memory            = cmd_free_memory,
+    allocate_shared_memory = cmd_allocate_shared_memory,
+    get_memory_protection  = cmd_get_memory_protection,
+    set_memory_protection  = cmd_set_memory_protection,
+    full_access            = cmd_full_access,
+    allocate_kernel_memory = cmd_allocate_kernel_memory,
+    -- >>> END UNIT-08 <<<
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,107 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# >>> BEGIN UNIT-08 Memory Allocation <<<
+
+@mcp.tool()
+def allocate_memory(size: int, base_address: str = None, protection: str = "rwx") -> str:
+    """Allocate memory in the target process.
+
+    Args:
+        size: Number of bytes to allocate.
+        base_address: Preferred base address as hex string (e.g. "0x140000000"). Optional.
+        protection: Access flags — "r" (read-only), "rw" (read-write),
+                    "rx" (read-execute), "rwx" (read-write-execute, default).
+
+    Returns JSON with: success, address.
+    """
+    params = {"size": size, "protection": protection}
+    if base_address is not None:
+        params["base_address"] = base_address
+    return format_result(ce_client.send_command("allocate_memory", params))
+
+@mcp.tool()
+def free_memory(address: str, size: int = 0) -> str:
+    """Free memory previously allocated in the target process.
+
+    Args:
+        address: Address of the region to free as hex string.
+        size: Size of the region in bytes. Use 0 to let the OS determine it (default).
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("free_memory", {"address": address, "size": size}))
+
+@mcp.tool()
+def allocate_shared_memory(name: str, size: int) -> str:
+    """Create and map a shared memory region in the target process.
+
+    The region is allocated with non-executable protection by default.
+
+    Args:
+        name: Unique name for the shared memory object.
+        size: Size in bytes. Defaults to 4096 if the region does not yet exist.
+
+    Returns JSON with: success, address.
+    """
+    return format_result(ce_client.send_command("allocate_shared_memory", {"name": name, "size": size}))
+
+@mcp.tool()
+def get_memory_protection(address: str) -> str:
+    """Query the protection flags of a memory page in the target process.
+
+    Args:
+        address: Address to query as hex string.
+
+    Returns JSON with: success, read (bool), write (bool), execute (bool), raw (PAGE_* name).
+    """
+    return format_result(ce_client.send_command("get_memory_protection", {"address": address}))
+
+@mcp.tool()
+def set_memory_protection(address: str, size: int, read: bool = True, write: bool = True, execute: bool = True) -> str:
+    """Change the protection flags of a memory region in the target process.
+
+    Args:
+        address: Start address as hex string.
+        size: Size in bytes of the region to protect.
+        read: Allow read access (default True).
+        write: Allow write access (default True).
+        execute: Allow execute access (default True).
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("set_memory_protection", {
+        "address": address, "size": size, "read": read, "write": write, "execute": execute
+    }))
+
+@mcp.tool()
+def full_access(address: str, size: int) -> str:
+    """Grant full read-write-execute access to a memory region (convenience wrapper).
+
+    Args:
+        address: Start address as hex string.
+        size: Size in bytes of the region.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("full_access", {"address": address, "size": size}))
+
+@mcp.tool()
+def allocate_kernel_memory(size: int) -> str:
+    """Allocate non-paged kernel memory via the DBK driver.
+
+    Requires the Cheat Engine kernel driver (DBK) to be loaded.
+
+    Args:
+        size: Number of bytes to allocate.
+
+    Returns JSON with: success, address.
+    Error codes: DBK_NOT_LOADED if the kernel driver is not active.
+    """
+    return format_result(ce_client.send_command("allocate_kernel_memory", {"size": size}))
+
+# >>> END UNIT-08 <<<
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
7 new MCP tools for memory allocation and page protection:
- `allocate_memory` / `free_memory` — target-process memory alloc.
- `allocate_shared_memory` — cross-process shared memory (default non-exec).
- `get_memory_protection` / `set_memory_protection` — page permission query and modify.
- `full_access` — convenience wrapper for RWX.
- `allocate_kernel_memory` — returns `DBK_NOT_LOADED` when driver is absent.

Protection strings ("r", "rw", "rx", "rwx") are mapped to CE constants via a local table.

## Unit
Unit 8 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)