### PR TITLE
feat(unit-10): debugger control tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,142 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-10 Debugger Control <<<
+-- ============================================================================
+-- COMMAND HANDLERS - DEBUGGER CONTROL (Unit 10)
+-- ============================================================================
+-- Wraps CE's native debugger control APIs: debugProcess, debug_isDebugging,
+-- debug_getCurrentDebuggerInterface, debug_breakThread,
+-- debug_continueFromBreakpoint, detachIfPossible, pause, unpause.
+--
+-- pause() and unpause() are confirmed CE global functions (celua.txt lines 441-442).
+-- co_run, co_stepinto, co_stepover are CE global constants used by
+-- debug_continueFromBreakpoint (celua.txt line 822).
+
+-- Maps debugProcess interface int to a readable name.
+-- Input domain: 0=default, 1=Windows(native), 2=VEH, 3=Kernel(DBK), 4=DBVM
+local DEBUGGER_INTERFACE_INPUT_NAME = {
+    [0] = "default",
+    [1] = "windows_native",
+    [2] = "veh",
+    [3] = "kernel_dbk",
+    [4] = "dbvm",
+}
+
+-- Maps debug_getCurrentDebuggerInterface() output to a readable name.
+-- CE docs: 1=windows, 2=VEH, 3=Kernel, 4=mac_native, 5=gdb, nil=none
+local DEBUGGER_INTERFACE_CURRENT_NAME = {
+    [1] = "windows_native",
+    [2] = "veh",
+    [3] = "kernel",
+    [4] = "mac_native",
+    [5] = "gdb",
+}
+
+local function cmd_debug_process(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return { success = false, error = "No process attached" }
+    end
+    local iface = params.interface or 0
+    if type(iface) ~= "number" then iface = tonumber(iface) or 0 end
+    local ok, err = pcall(debugProcess, iface)
+    if not ok then
+        return { success = false, error = tostring(err) }
+    end
+    return {
+        success = true,
+        interface_used = iface,
+        interface_name = DEBUGGER_INTERFACE_INPUT_NAME[iface] or "unknown",
+    }
+end
+
+local function cmd_debug_is_debugging(params)
+    local ok, result = pcall(debug_isDebugging)
+    if not ok then
+        return { success = false, error = tostring(result) }
+    end
+    return { success = true, is_debugging = result == true }
+end
+
+local function cmd_debug_get_current_debugger_interface(params)
+    local ok, iface = pcall(debug_getCurrentDebuggerInterface)
+    if not ok then
+        return { success = false, error = tostring(iface) }
+    end
+    local ifaceName = iface ~= nil
+        and (DEBUGGER_INTERFACE_CURRENT_NAME[iface] or ("unknown_" .. tostring(iface)))
+        or "none"
+    return {
+        success = true,
+        interface = iface,
+        interface_name = ifaceName,
+    }
+end
+
+-- Returns nil when the debugger is active, or an error table when it is not.
+local function requireDebugger()
+    local ok, isDbg = pcall(debug_isDebugging)
+    if not ok or not isDbg then
+        return { success = false, error = "Debugger is not attached" }
+    end
+end
+
+-- Calls fn() with no args, guarded by a NO_PROCESS check. Returns {success}.
+local function callWithProcessGuard(fn)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return { success = false, error = "No process attached" }
+    end
+    local ok, err = pcall(fn)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_debug_break_thread(params)
+    local guard = requireDebugger()
+    if guard then return guard end
+    local tid = params.thread_id
+    if type(tid) ~= "number" then tid = tonumber(tid) end
+    if not tid then
+        return { success = false, error = "Missing required param: thread_id" }
+    end
+    local ok, err = pcall(debug_breakThread, tid)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_debug_continue(params)
+    local guard = requireDebugger()
+    if guard then return guard end
+    local method = params.method or "run"
+    -- Map string to CE constant. co_run, co_stepinto, co_stepover are CE globals.
+    local ceMethod
+    if method == "run" then
+        ceMethod = co_run
+    elseif method == "step_into" then
+        ceMethod = co_stepinto
+    elseif method == "step_over" then
+        ceMethod = co_stepover
+    else
+        return { success = false, error = "Unknown method: " .. tostring(method) .. ". Valid: run, step_into, step_over" }
+    end
+    local ok, err = pcall(debug_continueFromBreakpoint, ceMethod)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_debug_detach(params)
+    local ok, result = pcall(detachIfPossible)
+    if not ok then return { success = false, error = tostring(result) } end
+    return { success = true, detached = result == true }
+end
+
+local function cmd_pause_process(params)   return callWithProcessGuard(pause)   end
+local function cmd_unpause_process(params) return callWithProcessGuard(unpause) end
+
+-- >>> END UNIT-10 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2267,16 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Debugger Control (Unit 10)
+    debug_process                      = cmd_debug_process,
+    debug_is_debugging                 = cmd_debug_is_debugging,
+    debug_get_current_debugger_interface = cmd_debug_get_current_debugger_interface,
+    debug_break_thread                 = cmd_debug_break_thread,
+    debug_continue                     = cmd_debug_continue,
+    debug_detach                       = cmd_debug_detach,
+    pause_process                      = cmd_pause_process,
+    unpause_process                    = cmd_unpause_process,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,78 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- DEBUGGER CONTROL (Unit 10) ---
+
+@mcp.tool()
+def debug_process(interface: int = 0) -> str:
+    """Start the CE debugger for the currently opened process.
+
+    interface: CE debugger interface enum.
+      0 = default, 1 = Windows native, 2 = VEH debugger,
+      3 = kernel debugger (DBK), 4 = DBVM.
+    Requires a process to be attached. Returns {success, interface_used, interface_name}.
+    """
+    return format_result(ce_client.send_command("debug_process", {"interface": interface}))
+
+@mcp.tool()
+def debug_is_debugging() -> str:
+    """Check whether the CE debugger has been started.
+
+    Always safe to call; no process guard. Returns {success, is_debugging: bool}.
+    """
+    return format_result(ce_client.send_command("debug_is_debugging"))
+
+@mcp.tool()
+def debug_get_current_debugger_interface() -> str:
+    """Return the active debugger interface used by CE.
+
+    Returns {success, interface: int | null, interface_name: str}.
+    interface_name values: 'windows_native', 'veh', 'kernel', 'mac_native', 'gdb', 'none'.
+    """
+    return format_result(ce_client.send_command("debug_get_current_debugger_interface"))
+
+@mcp.tool()
+def debug_break_thread(thread_id: int) -> str:
+    """Break a specific thread by its thread ID.
+
+    The thread may not stop instantly — it must be scheduled to run first.
+    Requires the debugger to be attached. Returns {success}.
+    """
+    return format_result(ce_client.send_command("debug_break_thread", {"thread_id": thread_id}))
+
+@mcp.tool()
+def debug_continue(method: str = "run") -> str:
+    """Continue execution from a breakpoint.
+
+    method: one of 'run' (co_run), 'step_into' (co_stepinto), 'step_over' (co_stepover).
+    Requires the debugger to be attached. Returns {success}.
+    """
+    return format_result(ce_client.send_command("debug_continue", {"method": method}))
+
+@mcp.tool()
+def debug_detach() -> str:
+    """Detach the debugger from the target process if possible.
+
+    Returns {success, detached: bool}. Safe to call when no debugger is active.
+    """
+    return format_result(ce_client.send_command("debug_detach"))
+
+@mcp.tool()
+def pause_process() -> str:
+    """Pause (freeze) the currently opened process using CE's global pause() function.
+
+    Requires a process to be attached. Returns {success}.
+    """
+    return format_result(ce_client.send_command("pause_process"))
+
+@mcp.tool()
+def unpause_process() -> str:
+    """Resume (unfreeze) the currently opened process using CE's global unpause() function.
+
+    Requires a process to be attached. Returns {success}.
+    """
+    return format_result(ce_client.send_command("unpause_process"))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
8 new MCP tools for debugger control:
- `debug_process` — start a debugger (interface 0-4).
- `debug_is_debugging` / `debug_get_current_debugger_interface` — state query.
- `debug_break_thread` — suspend a specific thread.
- `debug_continue` — resume from breakpoint (`run`/`step_into`/`step_over`).
- `debug_detach` — `detachIfPossible` wrapper.
- `pause_process` / `unpause_process` — freeze/unfreeze all threads.

Helpers extracted: `requireDebugger()` and `callWithProcessGuard()` to DRY the state-check patterns.

## Unit
Unit 10 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)