### PR TITLE
feat(unit-11): debug context inspection and per-thread breakpoints

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,251 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-11 Context + ThreadBPs <<<
+-- ============================================================================
+-- UNIT-11: DEBUG CONTEXT INSPECTION + PER-THREAD BREAKPOINTS
+-- ============================================================================
+
+local function u11_guard()
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return false, { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+    if not debug_isDebugging() then
+        return false, { success = false, error = "Debugger not active. Call debugProcess() first.", error_code = "NO_DEBUGGER" }
+    end
+    return true, nil
+end
+
+-- All settable register names shared between get and set handlers
+local U11_REG_NAMES = {
+    "RAX","RBX","RCX","RDX","RSI","RDI","RBP","RSP","RIP",
+    "R8","R9","R10","R11","R12","R13","R14","R15",
+    "EAX","EBX","ECX","EDX","ESI","EDI","EBP","ESP","EIP",
+    "EFLAGS"
+}
+
+local function cmd_debug_get_context(params)
+    local extraRegs = params.extra_regs == true
+
+    local ok, err = u11_guard()
+    if not ok then return err end
+
+    local callOk, callErr = pcall(debug_getContext, extraRegs)
+    if not callOk then
+        return { success = false, error = "debug_getContext failed: " .. tostring(callErr), error_code = "CE_API_ERROR" }
+    end
+
+    -- captureRegisters() reads the same CE globals that debug_getContext just populated
+    local regs = captureRegisters()
+    local arch  = regs.arch
+    regs.arch   = nil  -- arch is returned at top level, not inside registers
+
+    local result = { success = true, arch = arch, registers = regs }
+
+    if extraRegs then
+        local extra = {}
+        local is64  = arch == "x64"
+        -- XMM0-15 (0-7 on 32-bit): each pointer is a CE-local address of 16 raw bytes
+        local maxXmm = is64 and 15 or 7
+        for i = 0, maxXmm do
+            local xmmOk, xmmPtr = pcall(debug_getXMMPointer, i)
+            if xmmOk and xmmPtr then
+                local rawBytes = readBytes(xmmPtr, 16, true)
+                if rawBytes then
+                    local parts = {}
+                    for _, b in ipairs(rawBytes) do
+                        parts[#parts + 1] = string.format("%02X", b)
+                    end
+                    extra["xmm" .. i] = table.concat(parts)
+                end
+            end
+        end
+        -- FP0-FP7 are globals populated by debug_getContext(true)
+        local fpVars = { FP0, FP1, FP2, FP3, FP4, FP5, FP6, FP7 }
+        for i, v in ipairs(fpVars) do
+            if v ~= nil then extra["fp" .. (i - 1)] = tostring(v) end
+        end
+        result.extra = extra
+    end
+
+    return result
+end
+
+local function cmd_debug_set_context(params)
+    local registers = params.registers
+    if type(registers) ~= "table" then
+        return { success = false, error = "registers must be an object/dict", error_code = "INVALID_PARAMS" }
+    end
+
+    local ok, err = u11_guard()
+    if not ok then return err end
+
+    for _, name in ipairs(U11_REG_NAMES) do
+        local val = registers[name]
+        if val ~= nil then
+            local numVal
+            if type(val) == "string" then
+                numVal = tonumber(val, 16) or tonumber(val)
+            elseif type(val) == "number" then
+                numVal = val
+            end
+            if numVal then _G[name] = numVal end
+        end
+    end
+
+    local setOk, setErr = pcall(debug_setContext)
+    if not setOk then
+        return { success = false, error = "debug_setContext failed: " .. tostring(setErr), error_code = "CE_API_ERROR" }
+    end
+
+    return { success = true }
+end
+
+local function cmd_debug_get_xmm_pointer(params)
+    local xmmNr = params.xmm_nr or 0
+
+    local ok, err = u11_guard()
+    if not ok then return err end
+
+    local ptrOk, ptr = pcall(debug_getXMMPointer, xmmNr)
+    if not ptrOk then
+        return { success = false, error = "debug_getXMMPointer failed: " .. tostring(ptr), error_code = "CE_API_ERROR" }
+    end
+
+    return { success = true, xmm_nr = xmmNr, pointer = toHex(ptr) }
+end
+
+local function cmd_debug_set_last_branch_recording(params)
+    local enable = params.enable == true
+
+    local ok, err = u11_guard()
+    if not ok then return err end
+
+    -- LBR only works under kernel-mode debugger (interface == 3)
+    local iface = debug_getCurrentDebuggerInterface and debug_getCurrentDebuggerInterface() or nil
+    if iface ~= 3 then
+        return {
+            success            = false,
+            error              = "LBR requires kernel debugger",
+            error_code         = "CE_API_UNAVAILABLE",
+            debugger_interface = iface
+        }
+    end
+
+    local lbrOk, lbrErr = pcall(debug_setLastBranchRecording, enable)
+    if not lbrOk then
+        return { success = false, error = "debug_setLastBranchRecording failed: " .. tostring(lbrErr), error_code = "CE_API_ERROR" }
+    end
+
+    return { success = true, enabled = enable }
+end
+
+local function cmd_debug_get_last_branch_record(params)
+    local index = params.index or 0
+
+    local ok, err = u11_guard()
+    if not ok then return err end
+
+    local recOk, record = pcall(debug_getLastBranchRecord, index)
+    if not recOk then
+        return { success = false, error = "debug_getLastBranchRecord failed: " .. tostring(record), error_code = "CE_API_ERROR" }
+    end
+
+    if type(record) ~= "table" then
+        return { success = false, error = "Unexpected return from debug_getLastBranchRecord: " .. tostring(record), error_code = "CE_API_ERROR" }
+    end
+
+    return {
+        success = true,
+        index   = index,
+        from    = record.from and toHex(record.from) or nil,
+        to      = record.to   and toHex(record.to)   or nil,
+    }
+end
+
+local function cmd_debug_set_breakpoint_for_thread(params)
+    local threadId = params.thread_id
+    local addr     = params.address
+    local size     = params.size    or 1
+    local trigger  = params.trigger or "execute"
+
+    if not threadId then return { success = false, error = "thread_id is required", error_code = "INVALID_PARAMS" } end
+
+    local ok, err = u11_guard()
+    if not ok then return err end
+
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address", error_code = "INVALID_PARAMS" } end
+
+    local bpTrigger
+    if trigger == "write" then
+        bpTrigger = bptWrite
+    elseif trigger == "read" or trigger == "access" then
+        bpTrigger = bptAccess
+    else
+        bpTrigger = bptExecute
+    end
+
+    local bpHandle = "thread_" .. tostring(threadId) .. "_" .. toHex(addr)
+    serverState.breakpoint_hits[bpHandle] = {}
+
+    local setOk, setErr = pcall(debug_setBreakpointForThread, threadId, addr, size, bpTrigger, bpmDebugRegister, function()
+        table.insert(serverState.breakpoint_hits[bpHandle], {
+            handle    = bpHandle,
+            thread_id = threadId,
+            address   = toHex(addr),
+            timestamp = os.time(),
+            registers = captureRegisters(),
+        })
+        debug_continueFromBreakpoint(co_run)
+        return 1
+    end)
+
+    if not setOk then
+        serverState.breakpoint_hits[bpHandle] = nil
+        return { success = false, error = "debug_setBreakpointForThread failed: " .. tostring(setErr), error_code = "CE_API_ERROR" }
+    end
+
+    serverState.breakpoints[bpHandle] = { address = addr, type = "thread_bp", thread_id = threadId }
+
+    return {
+        success   = true,
+        bp_handle = bpHandle,
+        thread_id = threadId,
+        address   = toHex(addr),
+        trigger   = trigger,
+        size      = size,
+    }
+end
+
+local function cmd_debug_remove_breakpoint_for_thread(params)
+    local threadId = params.thread_id
+    local addr     = params.address
+
+    if not threadId then return { success = false, error = "thread_id is required", error_code = "INVALID_PARAMS" } end
+
+    local ok, err = u11_guard()
+    if not ok then return err end
+
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address", error_code = "INVALID_PARAMS" } end
+
+    -- CE has no dedicated per-thread remove; debug_removeBreakpoint by address is the supported path
+    local remOk, remErr = pcall(debug_removeBreakpoint, addr)
+    if not remOk then
+        return { success = false, error = "debug_removeBreakpoint failed: " .. tostring(remErr), error_code = "CE_API_ERROR" }
+    end
+
+    local bpHandle = "thread_" .. tostring(threadId) .. "_" .. toHex(addr)
+    serverState.breakpoints[bpHandle]     = nil
+    serverState.breakpoint_hits[bpHandle] = nil
+
+    return { success = true, thread_id = threadId, address = toHex(addr) }
+end
+
+-- >>> END UNIT-11 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2376,15 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Unit-11: Debug Context + Per-Thread Breakpoints
+    debug_get_context                  = cmd_debug_get_context,
+    debug_set_context                  = cmd_debug_set_context,
+    debug_get_xmm_pointer              = cmd_debug_get_xmm_pointer,
+    debug_set_last_branch_recording    = cmd_debug_set_last_branch_recording,
+    debug_get_last_branch_record       = cmd_debug_get_last_branch_record,
+    debug_set_breakpoint_for_thread    = cmd_debug_set_breakpoint_for_thread,
+    debug_remove_breakpoint_for_thread = cmd_debug_remove_breakpoint_for_thread,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,51 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- UNIT-11: DEBUG CONTEXT + PER-THREAD BREAKPOINTS ---
+
+@mcp.tool()
+def debug_get_context(extra_regs: bool = False) -> str:
+    """Get the current thread's CPU register context. Set extra_regs=True to include XMM0-15 and FP0-7."""
+    return format_result(ce_client.send_command("debug_get_context", {"extra_regs": extra_regs}))
+
+@mcp.tool()
+def debug_set_context(registers: dict) -> str:
+    """Set CPU register values in the paused thread. Pass a dict like {\"RAX\": \"0x1234\", \"RIP\": \"0x140001000\"}."""
+    return format_result(ce_client.send_command("debug_set_context", {"registers": registers}))
+
+@mcp.tool()
+def debug_get_xmm_pointer(xmm_nr: int = 0) -> str:
+    """Return the CE-local memory address of an XMM register (0-15) for the currently broken thread."""
+    return format_result(ce_client.send_command("debug_get_xmm_pointer", {"xmm_nr": xmm_nr}))
+
+@mcp.tool()
+def debug_set_last_branch_recording(enable: bool) -> str:
+    """Enable or disable Intel LBR (Last Branch Recording). Requires kernel-mode debugger."""
+    return format_result(ce_client.send_command("debug_set_last_branch_recording", {"enable": enable}))
+
+@mcp.tool()
+def debug_get_last_branch_record(index: int) -> str:
+    """Get the from/to addresses of a Last Branch Record entry at the given index."""
+    return format_result(ce_client.send_command("debug_get_last_branch_record", {"index": index}))
+
+@mcp.tool()
+def debug_set_breakpoint_for_thread(thread_id: int, address: str, size: int = 1, trigger: str = "execute") -> str:
+    """Set a breakpoint that fires only on a specific thread. trigger: execute|write|read|access."""
+    return format_result(ce_client.send_command("debug_set_breakpoint_for_thread", {
+        "thread_id": thread_id,
+        "address": address,
+        "size": size,
+        "trigger": trigger,
+    }))
+
+@mcp.tool()
+def debug_remove_breakpoint_for_thread(thread_id: int, address: str) -> str:
+    """Remove a per-thread breakpoint at the given address for the given thread."""
+    return format_result(ce_client.send_command("debug_remove_breakpoint_for_thread", {
+        "thread_id": thread_id,
+        "address": address,
+    }))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
7 new MCP tools:
- `debug_get_context` — full register snapshot including XMM/FP when `extra_regs=true`. Reuses the existing `captureRegisters()` helper.
- `debug_set_context` — modify registers before resuming.
- `debug_get_xmm_pointer` — pointer to the XMM register file.
- `debug_set_last_branch_recording` / `debug_get_last_branch_record` — Intel LBR tracing (kernel debugger required).
- `debug_set_breakpoint_for_thread` / `debug_remove_breakpoint_for_thread` — per-thread BPs separate from global ones.

## Unit
Unit 11 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)