### PR TITLE
feat(unit-12): symbol management tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,162 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-12 Symbol Management <<<
+local function cmd_register_symbol(params)
+    local name = params.name
+    local address = params.address
+    local do_not_save = params.do_not_save
+    if do_not_save == nil then do_not_save = false end
+    if type(name) ~= "string" or name == "" then
+        return { success = false, error = "Parameter 'name' must be a non-empty string", error_code = "INVALID_PARAMS" }
+    end
+    if type(address) ~= "string" and type(address) ~= "number" then
+        return { success = false, error = "Parameter 'address' must be a string or integer", error_code = "INVALID_PARAMS" }
+    end
+    local resolvedAddr = address
+    if type(address) == "string" then
+        resolvedAddr = getAddressSafe(address)
+    end
+    if not resolvedAddr or resolvedAddr == 0 then
+        return { success = false, error = "Invalid address: " .. tostring(address), error_code = "INVALID_ADDRESS" }
+    end
+    local ok, err = pcall(registerSymbol, name, resolvedAddr, do_not_save)
+    if not ok then
+        return { success = false, error = "registerSymbol failed: " .. tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true, name = name, address = toHex(resolvedAddr) }
+end
+
+local function cmd_unregister_symbol(params)
+    local name = params.name
+    if type(name) ~= "string" or name == "" then
+        return { success = false, error = "Parameter 'name' must be a non-empty string", error_code = "INVALID_PARAMS" }
+    end
+    local ok, err = pcall(unregisterSymbol, name)
+    if not ok then
+        return { success = false, error = "unregisterSymbol failed: " .. tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true }
+end
+
+local function cmd_enum_registered_symbols(params)
+    local ok, result = pcall(enumRegisteredSymbols)
+    if not ok then
+        return { success = false, error = "enumRegisteredSymbols failed: " .. tostring(result), error_code = "INTERNAL_ERROR" }
+    end
+    local symbols = {}
+    if result and type(result) == "table" then
+        for i = 1, #result do
+            local sym = result[i]
+            if sym then
+                local addrVal = sym.address or 0
+                local modName = sym.module or sym.modulename or ""
+                table.insert(symbols, {
+                    name    = sym.symbolname or sym.name or "",
+                    address = toHex(addrVal),
+                    module  = tostring(modName)
+                })
+            end
+        end
+    end
+    return { success = true, count = #symbols, symbols = symbols }
+end
+
+local function cmd_delete_all_registered_symbols(params)
+    -- Count before deleting (CE returns no count from deleteAllRegisteredSymbols)
+    local countOk, symResult = pcall(enumRegisteredSymbols)
+    local deletedCount = 0
+    if countOk and symResult and type(symResult) == "table" then
+        deletedCount = #symResult
+    end
+    local ok, err = pcall(deleteAllRegisteredSymbols)
+    if not ok then
+        return { success = false, error = "deleteAllRegisteredSymbols failed: " .. tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true, deleted_count = deletedCount }
+end
+
+local function cmd_enable_windows_symbols(params)
+    local ok, err = pcall(enableWindowsSymbols)
+    if not ok then
+        return { success = false, error = "enableWindowsSymbols failed: " .. tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true }
+end
+
+local function cmd_enable_kernel_symbols(params)
+    local ok, err = pcall(enableKernelSymbols)
+    if not ok then
+        local errMsg = tostring(err)
+        if errMsg:lower():find("dbk") or errMsg:lower():find("kernel") or errMsg:lower():find("driver") then
+            return { success = false, error = "Kernel driver not loaded", error_code = "DBK_NOT_LOADED" }
+        end
+        return { success = false, error = "enableKernelSymbols failed: " .. errMsg, error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true }
+end
+
+local function cmd_get_symbol_info(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+    local name = params.name
+    if type(name) ~= "string" or name == "" then
+        return { success = false, error = "Parameter 'name' must be a non-empty string", error_code = "INVALID_PARAMS" }
+    end
+    local ok, info = pcall(getSymbolInfo, name)
+    if not ok then
+        return { success = false, error = "getSymbolInfo failed: " .. tostring(info), error_code = "INTERNAL_ERROR" }
+    end
+    if not info then
+        return { success = false, error = "Symbol not found: " .. name, error_code = "NOT_FOUND" }
+    end
+    local addrVal = info.address or 0
+    local modName = info.modulename or info.module or ""
+    return {
+        success = true,
+        name    = info.searchkey or info.name or name,
+        address = toHex(addrVal),
+        module  = tostring(modName),
+        size    = info.size or 0
+    }
+end
+
+local function cmd_get_module_size(params)
+    if (getOpenedProcessID() or 0) == 0 then
+        return { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+    local module_name = params.module_name
+    if type(module_name) ~= "string" or module_name == "" then
+        return { success = false, error = "Parameter 'module_name' must be a non-empty string", error_code = "INVALID_PARAMS" }
+    end
+    local ok, sz = pcall(getModuleSize, module_name)
+    if not ok then
+        return { success = false, error = "getModuleSize failed: " .. tostring(sz), error_code = "INTERNAL_ERROR" }
+    end
+    if not sz then
+        return { success = false, error = "Module not found: " .. module_name, error_code = "NOT_FOUND" }
+    end
+    return { success = true, size = sz }
+end
+
+local function cmd_load_new_symbols(params)
+    local ok, err = pcall(loadNewSymbols)
+    if not ok then
+        return { success = false, error = "loadNewSymbols failed: " .. tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true }
+end
+
+local function cmd_reinitialize_symbol_handler(params)
+    local ok, err = pcall(reinitializeSymbolhandler)
+    if not ok then
+        return { success = false, error = "reinitializeSymbolhandler failed: " .. tostring(err), error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true }
+end
+-- >>> END UNIT-12 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2287,19 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- >>> BEGIN UNIT-12 dispatcher entries <<<
+    register_symbol                = cmd_register_symbol,
+    unregister_symbol              = cmd_unregister_symbol,
+    enum_registered_symbols        = cmd_enum_registered_symbols,
+    delete_all_registered_symbols  = cmd_delete_all_registered_symbols,
+    enable_windows_symbols         = cmd_enable_windows_symbols,
+    enable_kernel_symbols          = cmd_enable_kernel_symbols,
+    get_symbol_info                = cmd_get_symbol_info,
+    get_module_size                = cmd_get_module_size,
+    load_new_symbols               = cmd_load_new_symbols,
+    reinitialize_symbol_handler    = cmd_reinitialize_symbol_handler,
+    -- >>> END UNIT-12 <<<
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,113 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# >>> BEGIN UNIT-12 Symbol Management <<<
+@mcp.tool()
+def register_symbol(name: str, address: str, do_not_save: bool = False) -> str:
+    """Register a user-defined symbol with a given name and address.
+
+    Args:
+        name: Symbol name to register.
+        address: Address to bind to the symbol (hex string or decimal).
+        do_not_save: If True, this symbol is not persisted when the CE table is saved.
+
+    Returns JSON with: success, name, address.
+    """
+    return format_result(ce_client.send_command("register_symbol", {
+        "name": name, "address": address, "do_not_save": do_not_save
+    }))
+
+@mcp.tool()
+def unregister_symbol(name: str) -> str:
+    """Remove a previously registered user-defined symbol.
+
+    Args:
+        name: Symbol name to unregister.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("unregister_symbol", {"name": name}))
+
+@mcp.tool()
+def enum_registered_symbols() -> str:
+    """List all user-registered symbols.
+
+    Returns JSON with: success, count, symbols (list of {name, address, module}).
+    """
+    return format_result(ce_client.send_command("enum_registered_symbols"))
+
+@mcp.tool()
+def delete_all_registered_symbols() -> str:
+    """Delete every user-registered symbol (both AA and Lua).
+
+    Returns JSON with: success, deleted_count.
+    """
+    return format_result(ce_client.send_command("delete_all_registered_symbols"))
+
+@mcp.tool()
+def enable_windows_symbols() -> str:
+    """Trigger download and load of Windows PDB symbol files.
+
+    Note: The actual PDB download and indexing is asynchronous; this call returns
+    immediately once the process has been initiated by Cheat Engine.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("enable_windows_symbols"))
+
+@mcp.tool()
+def enable_kernel_symbols() -> str:
+    """Enable kernel-mode symbol resolution (requires DBK driver).
+
+    Returns JSON with: success.
+    On failure returns error_code DBK_NOT_LOADED if the kernel driver is absent.
+    """
+    return format_result(ce_client.send_command("enable_kernel_symbols"))
+
+@mcp.tool()
+def get_symbol_info(name: str) -> str:
+    """Retrieve detailed information about a known symbol.
+
+    Requires an attached process.
+
+    Args:
+        name: Symbol or export name to look up.
+
+    Returns JSON with: success, name, address, module, size.
+    Returns error_code NOT_FOUND if the symbol is unknown.
+    """
+    return format_result(ce_client.send_command("get_symbol_info", {"name": name}))
+
+@mcp.tool()
+def get_module_size(module_name: str) -> str:
+    """Get the in-memory size of a loaded module.
+
+    Requires an attached process.
+
+    Args:
+        module_name: Module filename (e.g. 'kernel32.dll').
+
+    Returns JSON with: success, size.
+    """
+    return format_result(ce_client.send_command("get_module_size", {"module_name": module_name}))
+
+@mcp.tool()
+def load_new_symbols() -> str:
+    """Scan for newly loaded modules and import their symbols.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("load_new_symbols"))
+
+@mcp.tool()
+def reinitialize_symbol_handler() -> str:
+    """Perform a full reset and reload of the Cheat Engine symbol handler.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("reinitialize_symbol_handler"))
+# >>> END UNIT-12 <<<
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
10 new MCP tools for symbol management:
- `register_symbol` / `unregister_symbol` — user-defined symbol registry.
- `enum_registered_symbols` / `delete_all_registered_symbols` — bulk ops.
- `enable_windows_symbols` / `enable_kernel_symbols` — PDB / kernel symbol loading (kernel returns `DBK_NOT_LOADED` if the driver is absent).
- `get_symbol_info` / `get_module_size` — metadata lookup.
- `load_new_symbols` / `reinitialize_symbol_handler` — reload triggers.

## Unit
Unit 12 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)