### PR TITLE
feat(unit-14): memory copy/compare/dump operations

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,209 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-14 Memory Operations <<<
+-- ============================================================================
+-- COMMAND HANDLERS - MEMORY OPERATIONS (Unit 14)
+-- ============================================================================
+
+local function sanitizeFilename(f)
+    if type(f) ~= "string" or f:find("%.%.") then return nil, "Invalid filename" end
+    return f, nil
+end
+
+local function cmd_copy_memory(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then return { success = false, error = "No process attached" } end
+
+    local src = params.source
+    local size = params.size
+    local dest = params.dest  -- may be nil
+    local method = params.method or 0
+
+    if not src then return { success = false, error = "Missing source address" } end
+    if not size or size <= 0 then return { success = false, error = "Missing or invalid size" } end
+
+    if type(src) == "string" then src = getAddressSafe(src) end
+    if not src then return { success = false, error = "Invalid source address" } end
+
+    local destAddr = nil
+    if dest ~= nil then
+        if type(dest) == "string" then destAddr = getAddressSafe(dest)
+        else destAddr = dest end
+        if not destAddr then return { success = false, error = "Invalid dest address" } end
+    end
+
+    local ok, result = pcall(copyMemory, src, size, destAddr, method)
+    if not ok or not result then
+        return { success = false, error = "copyMemory failed: " .. tostring(result) }
+    end
+
+    return { success = true, dest_address = toHex(result), size = size }
+end
+
+local function cmd_compare_memory(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then return { success = false, error = "No process attached" } end
+
+    local addr1 = params.addr1
+    local addr2 = params.addr2
+    local size = params.size
+    local method = params.method or 0
+
+    if not addr1 then return { success = false, error = "Missing addr1" } end
+    if not addr2 then return { success = false, error = "Missing addr2" } end
+    if not size or size <= 0 then return { success = false, error = "Missing or invalid size" } end
+
+    if type(addr1) == "string" then addr1 = getAddressSafe(addr1) end
+    if type(addr2) == "string" then addr2 = getAddressSafe(addr2) end
+    if not addr1 then return { success = false, error = "Invalid addr1" } end
+    if not addr2 then return { success = false, error = "Invalid addr2" } end
+
+    local ok, r1, r2 = pcall(compareMemory, addr1, addr2, size, method)
+    if not ok then
+        return { success = false, error = "compareMemory failed: " .. tostring(r1) }
+    end
+
+    if r1 == true then
+        return { success = true, equal = true, first_diff = -1 }
+    else
+        return { success = true, equal = false, first_diff = r2 or -1 }
+    end
+end
+
+local function cmd_write_region_to_file(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then return { success = false, error = "No process attached" } end
+
+    local addr = params.address
+    local size = params.size
+    local filename = params.filename
+
+    local sanitized, err = sanitizeFilename(filename)
+    if not sanitized then return { success = false, error = err } end
+
+    if not addr then return { success = false, error = "Missing address" } end
+    if not size or size <= 0 then return { success = false, error = "Missing or invalid size" } end
+
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address" } end
+
+    local ok, bytes_written = pcall(writeRegionToFile, sanitized, addr, size)
+    if not ok then
+        return { success = false, error = "writeRegionToFile failed: " .. tostring(bytes_written) }
+    end
+
+    return { success = true, bytes_written = bytes_written or 0, filename = sanitized }
+end
+
+local function cmd_read_region_from_file(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then return { success = false, error = "No process attached" } end
+
+    local filename = params.filename
+    local destination = params.destination
+
+    local sanitized, err = sanitizeFilename(filename)
+    if not sanitized then return { success = false, error = err } end
+
+    if not destination then return { success = false, error = "Missing destination address" } end
+
+    if type(destination) == "string" then destination = getAddressSafe(destination) end
+    if not destination then return { success = false, error = "Invalid destination address" } end
+
+    local ok, bytes_read = pcall(readRegionFromFile, sanitized, destination)
+    if not ok then
+        return { success = false, error = "readRegionFromFile failed: " .. tostring(bytes_read) }
+    end
+
+    return { success = true, bytes_read = bytes_read or 0 }
+end
+
+local function cmd_md5_memory(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then return { success = false, error = "No process attached" } end
+
+    local addr = params.address
+    local size = params.size
+
+    if not addr then return { success = false, error = "Missing address" } end
+    if not size or size <= 0 then return { success = false, error = "Missing or invalid size" } end
+
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address" } end
+
+    local ok, result = pcall(md5memory, addr, size)
+    if not ok or not result then
+        return { success = false, error = "md5memory failed: " .. tostring(result) }
+    end
+
+    return { success = true, md5 = tostring(result) }
+end
+
+local function cmd_md5_file(params)
+    local filename = params.filename
+
+    local sanitized, err = sanitizeFilename(filename)
+    if not sanitized then return { success = false, error = err } end
+
+    local ok, result = pcall(md5file, sanitized)
+    if not ok or not result then
+        return { success = false, error = "md5file failed: " .. tostring(result) }
+    end
+
+    return { success = true, md5 = tostring(result) }
+end
+
+local function cmd_create_section(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then return { success = false, error = "No process attached" } end
+
+    local size = params.size
+    if not size or size <= 0 then return { success = false, error = "Missing or invalid size" } end
+
+    local ok, handle = pcall(createSection, size)
+    if not ok or not handle then
+        return { success = false, error = "createSection failed: " .. tostring(handle) }
+    end
+
+    return { success = true, handle = toHex(handle) }
+end
+
+local function cmd_map_view_of_section(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then return { success = false, error = "No process attached" } end
+
+    local handle = params.handle
+    local address = params.address  -- optional preferred base
+
+    if not handle then return { success = false, error = "Missing handle" } end
+
+    if type(handle) == "string" then handle = tonumber(handle, 16) end
+    if not handle then return { success = false, error = "Invalid handle" } end
+
+    local prefAddr = nil
+    if address ~= nil then
+        if type(address) == "string" then prefAddr = getAddressSafe(address)
+        else prefAddr = address end
+        if not prefAddr then return { success = false, error = "Invalid address" } end
+    end
+
+    local ok, mapped
+    if prefAddr then
+        ok, mapped = pcall(mapViewOfSection, handle, prefAddr)
+    else
+        ok, mapped = pcall(mapViewOfSection, handle)
+    end
+
+    if not ok or not mapped then
+        return { success = false, error = "mapViewOfSection failed: " .. tostring(mapped) }
+    end
+
+    return { success = true, mapped_address = toHex(mapped) }
+end
+
+-- >>> END UNIT-14 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2334,16 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Memory Operations (Unit 14)
+    copy_memory = cmd_copy_memory,
+    compare_memory = cmd_compare_memory,
+    write_region_to_file = cmd_write_region_to_file,
+    read_region_from_file = cmd_read_region_from_file,
+    md5_memory = cmd_md5_memory,
+    md5_file = cmd_md5_file,
+    create_section = cmd_create_section,
+    map_view_of_section = cmd_map_view_of_section,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,60 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- MEMORY OPERATIONS (Unit 14) ---
+
+@mcp.tool()
+def copy_memory(source: str, size: int, dest: str = None, method: int = 0) -> str:
+    """Copy memory between addresses. Methods: 0=target→target, 1=target→CE, 2=CE→target, 3=CE→CE. Returns dest_address allocated by CE if dest is None."""
+    return format_result(ce_client.send_command("copy_memory", {
+        "source": source, "size": size, "dest": dest, "method": method
+    }))
+
+@mcp.tool()
+def compare_memory(addr1: str, addr2: str, size: int, method: int = 0) -> str:
+    """Compare two memory regions. Methods: 0=target/target, 1=addr1=target addr2=CE, 2=both CE. Returns equal flag and first_diff byte index (-1 if equal)."""
+    return format_result(ce_client.send_command("compare_memory", {
+        "addr1": addr1, "addr2": addr2, "size": size, "method": method
+    }))
+
+@mcp.tool()
+def write_region_to_file(address: str, size: int, filename: str) -> str:
+    """Write a memory region to a file. Filename must be an absolute path and must not contain '..' components."""
+    return format_result(ce_client.send_command("write_region_to_file", {
+        "address": address, "size": size, "filename": filename
+    }))
+
+@mcp.tool()
+def read_region_from_file(filename: str, destination: str) -> str:
+    """Read a file into memory at the given destination address. Filename must be an absolute path and must not contain '..' components."""
+    return format_result(ce_client.send_command("read_region_from_file", {
+        "filename": filename, "destination": destination
+    }))
+
+@mcp.tool()
+def md5_memory(address: str, size: int) -> str:
+    """Calculate the MD5 hash of a memory region. Returns the hash as a hex string."""
+    return format_result(ce_client.send_command("md5_memory", {
+        "address": address, "size": size
+    }))
+
+@mcp.tool()
+def md5_file(filename: str) -> str:
+    """Calculate the MD5 hash of a file on the CE host. Filename must not contain '..' components."""
+    return format_result(ce_client.send_command("md5_file", {"filename": filename}))
+
+@mcp.tool()
+def create_section(size: int) -> str:
+    """Create a Windows section (shared memory) of the given size. Returns a handle as a hex string."""
+    return format_result(ce_client.send_command("create_section", {"size": size}))
+
+@mcp.tool()
+def map_view_of_section(handle: str, address: str = None, size: int = 0) -> str:
+    """Map a section into the target process. 'handle' is from create_section. 'address' is optional preferred base. Returns mapped_address."""
+    return format_result(ce_client.send_command("map_view_of_section", {
+        "handle": handle, "address": address, "size": size
+    }))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
8 new MCP tools for memory operations:
- `copy_memory` / `compare_memory` — intra-/cross-process copy and binary comparison (method 0-3).
- `write_region_to_file` / `read_region_from_file` — dump and restore memory regions to/from disk.
- `md5_memory` / `md5_file` — hash helpers.
- `create_section` / `map_view_of_section` — Windows section API wrappers.

File-path parameters are sanitized against path traversal.

## Unit
Unit 14 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)