### PR TITLE
feat(unit-09): code injection and execution tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,141 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-09 Code Injection <<<
+-- ============================================================================
+-- COMMAND HANDLERS - CODE INJECTION & EXECUTION
+-- ============================================================================
+
+-- Lua 5.1 compat: 'unpack' moved to 'table.unpack' in Lua 5.2+
+local unpack = unpack or table.unpack
+
+local function requireProcess()
+    local pid = getOpenedProcessID()
+    return pid and pid > 0
+end
+
+local function cmd_inject_dll(params)
+    if not requireProcess() then return { success = false, error = "No process attached" } end
+    local filepath = params.filepath
+    if not filepath then return { success = false, error = "No filepath provided" } end
+    local skip = params.skip_symbol_reload or false
+
+    local ok, result = pcall(injectDLL, filepath, skip)
+    if not ok then
+        return { success = false, error = "injectDLL failed: " .. tostring(result) }
+    end
+    return { success = result == true }
+end
+
+local function cmd_inject_dotnet_dll(params)
+    if not requireProcess() then return { success = false, error = "No process attached" } end
+    local dllpath    = params.filepath
+    local className  = params.class_name
+    local methodName = params.method_name
+    local param      = params.param or ""
+    local timeout    = params.timeout
+    if timeout == nil then timeout = -1 end
+
+    if not dllpath    then return { success = false, error = "No filepath provided" } end
+    if not className  then return { success = false, error = "No class_name provided" } end
+    if not methodName then return { success = false, error = "No method_name provided" } end
+
+    local ok, result = pcall(injectDotNetDLL, dllpath, className, methodName, param, timeout)
+    if not ok then
+        return { success = false, error = "injectDotNetDLL failed: " .. tostring(result) }
+    end
+    return { success = true, result = result }
+end
+
+local function cmd_execute_code(params)
+    if not requireProcess() then return { success = false, error = "No process attached" } end
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address" } end
+
+    local param   = params.param   or 0
+    local timeout = params.timeout
+    if timeout == nil then timeout = -1 end
+
+    local ok, retval = pcall(executeCode, addr, param, timeout)
+    if not ok then
+        return { success = false, error = "executeCode failed: " .. tostring(retval) }
+    end
+    return { success = true, return_value = retval }
+end
+
+local function cmd_execute_code_ex(params)
+    if not requireProcess() then return { success = false, error = "No process attached" } end
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address" } end
+
+    local callMethod = params.call_method or 0
+    local timeout    = params.timeout
+    if timeout == nil then timeout = -1 end
+    local args = params.args or {}
+
+    local ok, retval = pcall(executeCodeEx, callMethod, timeout, addr, unpack(args))
+    if not ok then
+        return { success = false, error = "executeCodeEx failed: " .. tostring(retval) }
+    end
+    return { success = true, return_value = retval }
+end
+
+local function cmd_execute_method(params)
+    if not requireProcess() then return { success = false, error = "No process attached" } end
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address" } end
+
+    local instance = params.instance
+    if type(instance) == "string" then instance = getAddressSafe(instance) end
+
+    local callMethod = params.call_method or 0
+    local timeout    = params.timeout
+    if timeout == nil then timeout = -1 end
+    local args = params.args or {}
+
+    local ok, retval = pcall(executeMethod, callMethod, timeout, addr, instance, unpack(args))
+    if not ok then
+        return { success = false, error = "executeMethod failed: " .. tostring(retval) }
+    end
+    return { success = true, return_value = retval }
+end
+
+-- No requireProcess() guard: runs in CE's own process, not the target.
+local function cmd_execute_code_local(params)
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address" } end
+
+    local param = params.param or 0
+
+    local ok, retval = pcall(executeCodeLocal, addr, param)
+    if not ok then
+        return { success = false, error = "executeCodeLocal failed: " .. tostring(retval) }
+    end
+    return { success = true, return_value = retval }
+end
+
+-- No requireProcess() guard: runs in CE's own process, not the target.
+local function cmd_execute_code_local_ex(params)
+    local addr = params.address
+    if type(addr) == "string" then addr = getAddressSafe(addr) end
+    if not addr then return { success = false, error = "Invalid address" } end
+
+    local callMethod = params.call_method or 0
+    local args = params.args or {}
+
+    local ok, retval = pcall(executeCodeLocalEx, callMethod, addr, unpack(args))
+    if not ok then
+        return { success = false, error = "executeCodeLocalEx failed: " .. tostring(retval) }
+    end
+    return { success = true, return_value = retval }
+end
+
+-- >>> END UNIT-09 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2266,15 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Code Injection & Execution (Unit-09)
+    inject_dll            = cmd_inject_dll,
+    inject_dotnet_dll     = cmd_inject_dotnet_dll,
+    execute_code          = cmd_execute_code,
+    execute_code_ex       = cmd_execute_code_ex,
+    execute_method        = cmd_execute_method,
+    execute_code_local    = cmd_execute_code_local,
+    execute_code_local_ex = cmd_execute_code_local_ex,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,195 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- CODE INJECTION & EXECUTION ---
+
+@mcp.tool()
+def inject_dll(filepath: str, skip_symbol_reload: bool = False) -> str:
+    """Inject a DLL into the currently attached target process.
+
+    Security warning: Executes arbitrary code in the target process. Use with caution.
+
+    Args:
+        filepath: Absolute path to the DLL or dylib to inject.
+        skip_symbol_reload: If True, skips waiting for symbol reload after injection.
+
+    Returns:
+        JSON with {success}.
+    """
+    return format_result(ce_client.send_command("inject_dll", {
+        "filepath": filepath,
+        "skip_symbol_reload": skip_symbol_reload,
+    }))
+
+@mcp.tool()
+def inject_dotnet_dll(
+    filepath: str,
+    class_name: str,
+    method_name: str,
+    param: str = "",
+    timeout: int = -1,
+) -> str:
+    """Inject a .NET DLL and invoke a static method in the target process.
+
+    Security warning: Executes arbitrary code in the target process. Use with caution.
+
+    The method must be declared as: public static int MethodName(string parameters).
+
+    Args:
+        filepath: Absolute path to the managed (.NET) DLL.
+        class_name: Fully-qualified class name (e.g. 'MyNamespace.MyClass').
+        method_name: Name of the static method to call.
+        param: String parameter passed to the method.
+        timeout: Milliseconds to wait for return (-1 = wait indefinitely).
+
+    Returns:
+        JSON with {success, result} where result is the integer return value.
+    """
+    return format_result(ce_client.send_command("inject_dotnet_dll", {
+        "filepath":    filepath,
+        "class_name":  class_name,
+        "method_name": method_name,
+        "param":       param,
+        "timeout":     timeout,
+    }))
+
+@mcp.tool()
+def execute_code(address: str, param: int = 0, timeout: int = -1) -> str:
+    """Call a stdcall function with one argument at the given address in the target process.
+
+    Security warning: Executes arbitrary code in the target process. Use with caution.
+
+    Args:
+        address: Address (hex string or symbol) of the function to call.
+        param: Integer argument passed as the single parameter.
+        timeout: Milliseconds to wait (-1 = indefinitely).
+
+    Returns:
+        JSON with {success, return_value}.
+    """
+    return format_result(ce_client.send_command("execute_code", {
+        "address": address,
+        "param":   param,
+        "timeout": timeout,
+    }))
+
+@mcp.tool()
+def execute_code_ex(
+    call_method: int,
+    timeout: int,
+    address: str,
+    args: list = None,
+) -> str:
+    """Call a function with an explicit calling convention and multiple arguments.
+
+    Security warning: Executes arbitrary code in the target process. Use with caution.
+
+    call_method values:
+        0 = stdcall
+        1 = cdecl
+        2 = thiscall
+        3 = fastcall
+
+    Args:
+        call_method: Integer calling convention identifier.
+        timeout: Milliseconds to wait (-1 = indefinitely, 0 = fire-and-forget).
+        address: Address (hex string or symbol) of the function to call.
+        args: List of arguments. Each element can be a raw value (CE guesses type)
+              or a dict with keys 'type' and 'value'.
+
+    Returns:
+        JSON with {success, return_value}.
+    """
+    return format_result(ce_client.send_command("execute_code_ex", {
+        "call_method": call_method,
+        "timeout":     timeout,
+        "address":     address,
+        "args":        args or [],
+    }))
+
+@mcp.tool()
+def execute_method(
+    address: str,
+    instance: str,
+    args: list = None,
+    call_method: int = 0,
+    timeout: int = -1,
+) -> str:
+    """Call a C++ instance method with an implicit 'this' pointer in the target process.
+
+    Security warning: Executes arbitrary code in the target process. Use with caution.
+
+    The instance pointer is placed into the register selected by call_method (ECX by default
+    for thiscall). If instance is None the call behaves like execute_code_ex.
+
+    Args:
+        address: Address (hex string or symbol) of the method to call.
+        instance: Address of the object instance ('this' pointer).
+        args: List of additional arguments passed after 'this'.
+        call_method: Calling convention (0=stdcall, 1=cdecl, 2=thiscall, 3=fastcall).
+        timeout: Milliseconds to wait (-1 = indefinitely).
+
+    Returns:
+        JSON with {success, return_value}.
+    """
+    return format_result(ce_client.send_command("execute_method", {
+        "address":     address,
+        "instance":    instance,
+        "args":        args or [],
+        "call_method": call_method,
+        "timeout":     timeout,
+    }))
+
+@mcp.tool()
+def execute_code_local(address: str, param: int = 0) -> str:
+    """Call a stdcall function inside Cheat Engine's own process (NOT the target).
+
+    Security warning: Executes arbitrary code in the CE process. Use with caution.
+
+    Useful for calling CE internal helpers or code loaded into CE itself.
+
+    Args:
+        address: Address within CE's memory space to call.
+        param: Integer argument passed as the single parameter.
+
+    Returns:
+        JSON with {success, return_value}.
+    """
+    return format_result(ce_client.send_command("execute_code_local", {
+        "address": address,
+        "param":   param,
+    }))
+
+@mcp.tool()
+def execute_code_local_ex(
+    address: str,
+    args: list = None,
+    call_method: int = 0,
+) -> str:
+    """Call a function inside Cheat Engine's own process with explicit calling convention.
+
+    Security warning: Executes arbitrary code in the CE process. Use with caution.
+
+    call_method values:
+        0 = stdcall
+        1 = cdecl
+        2 = thiscall
+        3 = fastcall
+
+    Args:
+        address: Address within CE's memory space to call.
+        args: List of arguments passed to the function.
+        call_method: Integer calling convention identifier.
+
+    Returns:
+        JSON with {success, return_value}.
+    """
+    return format_result(ce_client.send_command("execute_code_local_ex", {
+        "address":     address,
+        "args":        args or [],
+        "call_method": call_method,
+    }))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
7 new MCP tools for code injection and execution:
- `inject_dll` / `inject_dotnet_dll` — DLL/managed-code injection into target.
- `execute_code` / `execute_code_ex` / `execute_method` — invoke target functions (stdcall/cdecl/thiscall/fastcall, with optional `this` pointer).
- `execute_code_local` / `execute_code_local_ex` — run code in CE's own process (no target guard).

All variants wrap `pcall`; docstrings carry prominent arbitrary-code-execution warnings.

## Unit
Unit 9 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)