### PR TITLE
feat(unit-13): assembly and compilation tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,211 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-13 Assembly & Compilation <<<
+-- ============================================================================
+-- ASSEMBLY & COMPILATION TOOLS (Unit 13)
+-- ============================================================================
+
+-- Helper: check process is attached (for tools that need a target process address)
+local function requireProcess()
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return false, { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+    return true, nil
+end
+
+local function cmd_assemble_instruction(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local line = params.line
+    local address = params.address
+    local preference = params.preference or 0
+    local skipRangeCheck = params.skip_range_check or false
+
+    if not line or line == "" then
+        return { success = false, error = "No instruction line provided" }
+    end
+
+    if type(address) == "string" then address = getAddressSafe(address) end
+    if address == nil and params.address ~= nil then
+        return { success = false, error = "Invalid address: " .. tostring(params.address) }
+    end
+
+    -- assemble() accepts nil address; it skips relative-offset resolution in that case
+    local asmOk, result = pcall(assemble, line, address, preference, skipRangeCheck)
+
+    if not asmOk then
+        return { success = false, error = "assemble() raised error: " .. tostring(result) }
+    end
+
+    if not result then
+        return { success = false, error = "assemble() returned nil (invalid instruction or address)" }
+    end
+
+    local bytes = {}
+    for i = 1, #result do bytes[i] = result[i] end
+
+    return { success = true, bytes = bytes, size = #bytes }
+end
+
+local function cmd_auto_assemble_check(params)
+    local script = params.script
+    local enable = params.enable
+    if enable == nil then enable = true end
+    local targetSelf = params.target_self or false
+
+    if not script or script == "" then
+        return { success = false, error = "No script provided" }
+    end
+
+    local checkOk, valid, errMsg = pcall(autoAssembleCheck, script, enable, targetSelf)
+
+    if not checkOk then
+        return { success = false, valid = false, errors = { tostring(valid) } }
+    end
+
+    if valid then
+        return { success = true, valid = true, errors = {} }
+    end
+
+    local errors = {}
+    if errMsg then table.insert(errors, tostring(errMsg)) end
+    return { success = true, valid = false, errors = errors }
+end
+
+local function cmd_compile_c_code(params)
+    -- No NO_PROCESS guard: pure compilation without an address doesn't require a target process
+    local source = params.source
+    local address = params.address
+    local targetSelf = params.target_self or false
+    local kernelMode = params.kernelmode or false
+
+    if not source or source == "" then
+        return { success = false, error = "No source code provided" }
+    end
+
+    if type(compile) ~= "function" then
+        return { success = false, error = "TCC compiler not available", error_code = "CE_API_UNAVAILABLE" }
+    end
+
+    if type(address) == "string" then address = getAddressSafe(address) end
+    if address == nil and params.address ~= nil then
+        return { success = false, error = "Invalid address: " .. tostring(params.address) }
+    end
+
+    local compOk, symbols, errMsg = pcall(compile, source, address, targetSelf, kernelMode, false)
+
+    if not compOk then
+        return { success = false, symbols = {}, errors = { tostring(symbols) } }
+    end
+
+    if not symbols then
+        local errors = {}
+        if errMsg then table.insert(errors, tostring(errMsg)) end
+        return { success = false, symbols = {}, errors = errors }
+    end
+
+    local symResult = {}
+    for name, addr in pairs(symbols) do
+        symResult[tostring(name)] = toHex(addr)
+    end
+
+    return { success = true, symbols = symResult, errors = {} }
+end
+
+local function cmd_compile_cs_code(params)
+    local source = params.source
+    local references = params.references or {}
+    local coreAssembly = params.core_assembly
+
+    if not source or source == "" then
+        return { success = false, error = "No source code provided" }
+    end
+
+    if type(compileCS) ~= "function" then
+        return { success = false, error = ".NET runtime or compileCS not available", error_code = "CE_API_UNAVAILABLE" }
+    end
+
+    -- compileCS(text, references, coreAssembly OPTIONAL) — pass coreAssembly only when provided
+    local csOk, result = pcall(compileCS, source, references, coreAssembly)
+
+    if not csOk then
+        return { success = false, assembly_handle = nil, error = tostring(result) }
+    end
+
+    if not result then
+        return { success = false, assembly_handle = nil, error = "compileCS returned nil" }
+    end
+
+    return { success = true, assembly_handle = tostring(result) }
+end
+
+local function cmd_generate_api_hook_script(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local address = params.address
+    local targetAddress = params.target_address
+    local codeToExecute = params.code_to_execute or ""
+
+    if not address then return { success = false, error = "No address provided" } end
+    if not targetAddress then return { success = false, error = "No target_address provided" } end
+
+    if type(address) == "string" then address = getAddressSafe(address) end
+    if type(targetAddress) == "string" then targetAddress = getAddressSafe(targetAddress) end
+
+    if not address then return { success = false, error = "Invalid address: " .. tostring(params.address) } end
+    if not targetAddress then return { success = false, error = "Invalid target_address: " .. tostring(params.target_address) } end
+
+    -- CE signature: generateAPIHookScript(address, addresstojumpto, addresstogetnewcalladdress OPT, ext OPT, targetself OPT)
+    -- code_to_execute maps to ext (4th param); 3rd param (new-call-address) is unused here
+    local ext = codeToExecute ~= "" and codeToExecute or nil
+    local genOk, result = pcall(generateAPIHookScript, address, targetAddress, nil, ext)
+
+    if not genOk then
+        return { success = false, error = "generateAPIHookScript failed: " .. tostring(result) }
+    end
+
+    if not result then
+        return { success = false, error = "generateAPIHookScript returned nil" }
+    end
+
+    return { success = true, script = tostring(result) }
+end
+
+local function cmd_generate_code_injection_script(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local address = params.address
+    if not address then return { success = false, error = "No address provided" } end
+
+    if type(address) == "string" then address = getAddressSafe(address) end
+    if not address then return { success = false, error = "Invalid address: " .. tostring(params.address) } end
+
+    -- generateCodeInjectionScript(script: TStrings, address, farjmp) mutates TStrings in-place
+    local sl = createStringlist()
+    local genOk, genErr = pcall(generateCodeInjectionScript, sl, address)
+
+    if not genOk then
+        sl.destroy()
+        return { success = false, error = "generateCodeInjectionScript failed: " .. tostring(genErr) }
+    end
+
+    local script = sl.Text
+    sl.destroy()
+
+    if not script or script == "" then
+        return { success = false, error = "generateCodeInjectionScript produced empty script" }
+    end
+
+    return { success = true, script = script }
+end
+
+-- >>> END UNIT-13 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2336,14 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Assembly & Compilation (Unit 13)
+    assemble_instruction = cmd_assemble_instruction,
+    auto_assemble_check = cmd_auto_assemble_check,
+    compile_c_code = cmd_compile_c_code,
+    compile_cs_code = cmd_compile_cs_code,
+    generate_api_hook_script = cmd_generate_api_hook_script,
+    generate_code_injection_script = cmd_generate_code_injection_script,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -485,6 +485,117 @@ def auto_assemble(script: str) -> str:
     return format_result(ce_client.send_command("auto_assemble", {"script": script}))
 
 @mcp.tool()
+def assemble_instruction(
+    line: str,
+    address: str = None,
+    preference: int = 0,
+    skip_range_check: bool = False,
+) -> str:
+    """Assemble a single x86/x64 instruction into bytes.
+
+    Requires an attached process when an address is given (the address is used to
+    resolve relative operands such as JMP targets).
+
+    Returns {success, bytes: [int], size: int}.
+    preference: 0=none, 1=short, 2=long, 3=far.
+    """
+    params: dict = {"line": line, "preference": preference, "skip_range_check": skip_range_check}
+    if address is not None:
+        params["address"] = address
+    return format_result(ce_client.send_command("assemble_instruction", params))
+
+
+@mcp.tool()
+def auto_assemble_check(
+    script: str,
+    enable: bool = True,
+    target_self: bool = False,
+) -> str:
+    """Validate an Auto Assembler script for syntax errors without executing it.
+
+    Returns {success, valid: bool, errors: [str]}.
+    enable: True checks the [Enable] section; False checks [Disable].
+    target_self: if True, validates against CE's own process instead of the target.
+    """
+    return format_result(ce_client.send_command("auto_assemble_check", {
+        "script": script,
+        "enable": enable,
+        "target_self": target_self,
+    }))
+
+
+@mcp.tool()
+def compile_c_code(
+    source: str,
+    address: str = None,
+    target_self: bool = False,
+    kernelmode: bool = False,
+) -> str:
+    """Compile C source code using CE's built-in TCC compiler.
+
+    Does not require an attached process unless an address is provided.
+    Returns {success, symbols: {name: address}, errors: [str]}.
+    If TCC is unavailable: {success=false, error="TCC compiler not available",
+    error_code="CE_API_UNAVAILABLE"}.
+    """
+    params: dict = {"source": source, "target_self": target_self, "kernelmode": kernelmode}
+    if address is not None:
+        params["address"] = address
+    return format_result(ce_client.send_command("compile_c_code", params))
+
+
+@mcp.tool()
+def compile_cs_code(
+    source: str,
+    references: list = None,
+    core_assembly: str = None,
+) -> str:
+    """Compile C# source code using CE's .NET compiler (requires .NET 4+).
+
+    Returns {success, assembly_handle: str} where assembly_handle is the path to
+    the generated assembly. On .NET runtime absent:
+    {success=false, error_code="CE_API_UNAVAILABLE"}.
+    """
+    params: dict = {"source": source, "references": references or []}
+    if core_assembly is not None:
+        params["core_assembly"] = core_assembly
+    return format_result(ce_client.send_command("compile_cs_code", params))
+
+
+@mcp.tool()
+def generate_api_hook_script(
+    address: str,
+    target_address: str,
+    code_to_execute: str = "",
+) -> str:
+    """Generate an Auto Assembler script that hooks a function and redirects it.
+
+    Requires an attached process. address is the function to hook;
+    target_address is where execution should jump after the hook.
+    code_to_execute is optional extra AA code inserted into the generated script.
+    Returns {success, script: str}.
+    """
+    return format_result(ce_client.send_command("generate_api_hook_script", {
+        "address": address,
+        "target_address": target_address,
+        "code_to_execute": code_to_execute,
+    }))
+
+
+@mcp.tool()
+def generate_code_injection_script(address: str) -> str:
+    """Generate a boilerplate code-injection Auto Assembler script for an address.
+
+    Requires an attached process.
+    Returns {success, script: str} — the script can be used as a starting point
+    for patching code at that location.
+    """
+    return format_result(ce_client.send_command("generate_code_injection_script", {
+        "address": address,
+    }))
+
+
+@mcp.tool()
 def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))


### PR DESCRIPTION
## Summary
6 new MCP tools for assembly and compilation:
- `assemble_instruction` — single-instruction assembly; returns bytes array.
- `auto_assemble_check` — AutoAssembler script validation without execution.
- `compile_c_code` — TCC-based C compilation (returns `CE_API_UNAVAILABLE` when TCC is absent).
- `compile_cs_code` — .NET C# compilation.
- `generate_api_hook_script` / `generate_code_injection_script` — helper script generators.

## Unit
Unit 13 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)