### PR TITLE
feat(unit-15): advanced scanning (module-scoped, unique, persistent)

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -168,11 +168,23 @@ local function cleanupZombieState()
         serverState.scan_foundlist = nil
     end
 
+    -- 4. Cleanup persistent scans (Unit 15)
+    if serverState.persistent_scans then
+        for name, entry in pairs(serverState.persistent_scans) do
+            if entry then
+                if entry.fl then pcall(function() entry.fl.destroy() end) end
+                pcall(function() entry.ms.destroy() end)
+                cleaned.scans = cleaned.scans + 1
+            end
+        end
+    end
+
     -- Reset all tracking tables
     serverState.breakpoints = {}
     serverState.breakpoint_hits = {}
     serverState.hw_bp_slots = {}
     serverState.active_watches = {}
+    serverState.persistent_scans = {}
     
     if cleaned.breakpoints > 0 or cleaned.dbvm_watches > 0 or cleaned.scans > 0 then
         log(string.format("Cleaned: %d breakpoints, %d DBVM watches, %d scans", 
@@ -2054,6 +2066,387 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-15 Advanced Scanning <<<
+-- ============================================================================
+-- UNIT 15: Advanced Scanning (module-scoped, unique, persistent)
+-- ============================================================================
+
+-- Persistent scan state (Unit 15)
+serverState.persistent_scans = serverState.persistent_scans or {}
+
+-- Helper: NO_PROCESS guard used by all Unit-15 commands
+local function requireProcess()
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return false, { success = false, error = "No process attached", error_code = "NO_PROCESS" }
+    end
+    return true, nil
+end
+
+-- Helper: map human-readable var-type string to CE constant
+local function resolveVarType(vtype)
+    local t = (vtype or "dword"):lower()
+    if t == "byte"   then return vtByte
+    elseif t == "word"   then return vtWord
+    elseif t == "dword"  then return vtDword
+    elseif t == "qword"  then return vtQword
+    elseif t == "float"  then return vtSingle
+    elseif t == "double" then return vtDouble
+    elseif t == "string" then return vtString
+    else return vtDword
+    end
+end
+
+-- Helper: map human-readable scan_option to CE constant
+local function resolveScanOption(opt)
+    local o = (opt or "exact"):lower()
+    if o == "exact"          then return soExactValue
+    elseif o == "unknown"    then return soUnknownValue
+    elseif o == "between"    then return soValueBetween
+    elseif o == "bigger"     then return soBiggerThan
+    elseif o == "smaller"    then return soSmallerThan
+    elseif o == "increased"  then return soIncreasedValue
+    elseif o == "decreased"  then return soDecreasedValue
+    elseif o == "changed"    then return soChanged
+    elseif o == "unchanged"  then return soUnchanged
+    else return soExactValue
+    end
+end
+
+local function cmd_aob_scan_unique(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local pattern    = params.pattern
+    local protection = params.protection or "+X"
+
+    if not pattern then
+        return { success = false, error = "No pattern provided", error_code = "INVALID_PARAMS" }
+    end
+
+    -- AOBScan lets us count matches; AOBScanUnique returns first-found (non-deterministic on multiple hits)
+    local results
+    local scanOk, scanMsg = pcall(function()
+        results = AOBScan(pattern, protection)
+    end)
+    if not scanOk then
+        return { success = false, error = "AOBScan failed: " .. tostring(scanMsg), error_code = "SCAN_ERROR" }
+    end
+
+    local count = results and results.Count or 0
+    if count ~= 1 then
+        if results then pcall(function() results.destroy() end) end
+        return {
+            success    = false,
+            error      = "Pattern matched " .. tostring(count) .. " times (expected 1)",
+            error_code = "INVALID_PARAMS",
+            count      = count
+        }
+    end
+
+    local addrStr = results.getString(0)
+    local addr    = tonumber(addrStr, 16)
+    pcall(function() results.destroy() end)
+
+    return {
+        success = true,
+        address = "0x" .. (addrStr or "0"),
+        value   = addr
+    }
+end
+
+local function cmd_aob_scan_module(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local pattern     = params.pattern
+    local module_name = params.module_name
+    local protection  = params.protection or "+X"
+
+    if not pattern     then return { success = false, error = "No pattern provided",     error_code = "INVALID_PARAMS" } end
+    if not module_name then return { success = false, error = "No module_name provided", error_code = "INVALID_PARAMS" } end
+
+    local modBase, modSize
+    local modBaseOk = pcall(function() modBase = getAddress(module_name) end)
+    if not modBaseOk or not modBase or modBase == 0 then
+        return { success = false, error = "Module not found: " .. tostring(module_name), error_code = "INVALID_PARAMS" }
+    end
+
+    local modSizeOk = pcall(function() modSize = getModuleSize(module_name) end)
+    if not modSizeOk or not modSize or modSize == 0 then
+        return { success = false, error = "Cannot get module size for: " .. tostring(module_name), error_code = "INVALID_PARAMS" }
+    end
+
+    local modEnd = modBase + modSize
+
+    local results
+    local scanOk, scanMsg = pcall(function() results = AOBScan(pattern, protection) end)
+    if not scanOk then
+        return { success = false, error = "AOBScan failed: " .. tostring(scanMsg), error_code = "SCAN_ERROR" }
+    end
+
+    local addresses = {}
+    if results and results.Count > 0 then
+        for i = 0, results.Count - 1 do
+            local addrStr = results.getString(i)
+            local addr    = tonumber(addrStr, 16)
+            if addr and addr >= modBase and addr < modEnd then
+                table.insert(addresses, "0x" .. addrStr)
+            end
+        end
+    end
+    if results then pcall(function() results.destroy() end) end
+
+    return {
+        success     = true,
+        count       = #addresses,
+        module_name = module_name,
+        pattern     = pattern,
+        addresses   = addresses
+    }
+end
+
+local function cmd_aob_scan_module_unique(params)
+    -- requireProcess() is also called inside cmd_aob_scan_module; early-exit here gives a cleaner error path
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local r = cmd_aob_scan_module(params)
+    if not r.success then return r end
+
+    local count = r.count or 0
+    if count ~= 1 then
+        return {
+            success    = false,
+            error      = "Pattern matched " .. tostring(count) .. " times in module (expected 1)",
+            error_code = "INVALID_PARAMS",
+            count      = count
+        }
+    end
+
+    return {
+        success = true,
+        address = r.addresses[1],
+        module_name = params.module_name
+    }
+end
+
+local function cmd_pointer_rescan(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local value               = params.value
+    local previous_results_file = params.previous_results_file
+
+    if not value then
+        return { success = false, error = "No value provided", error_code = "INVALID_PARAMS" }
+    end
+
+    local rescanOk, rescanMsg = pcall(function()
+        if previous_results_file then
+            pointerRescan(value, previous_results_file)
+        else
+            pointerRescan(value)
+        end
+    end)
+
+    if not rescanOk then
+        return {
+            success    = false,
+            error      = "pointerRescan failed: " .. tostring(rescanMsg),
+            error_code = "SCAN_ERROR",
+            note       = "A prior pointer scan must exist in CE before calling pointer_rescan"
+        }
+    end
+
+    return { success = true, result_count = -1, note = "Pointer rescan complete. Check CE Pointer Scanner window for results." }
+end
+
+local function cmd_create_persistent_scan(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local name = params.name
+    if not name or name == "" then
+        return { success = false, error = "No name provided", error_code = "INVALID_PARAMS" }
+    end
+
+    local existing = serverState.persistent_scans[name]
+    if existing then
+        if existing.fl then pcall(function() existing.fl.destroy() end) end
+        pcall(function() existing.ms.destroy() end)
+        serverState.persistent_scans[name] = nil
+    end
+
+    local ms
+    local msOk, msMsg = pcall(function() ms = createMemScan() end)
+    if not msOk or not ms then
+        return { success = false, error = "createMemScan failed: " .. tostring(msMsg), error_code = "SCAN_ERROR" }
+    end
+
+    serverState.persistent_scans[name] = {
+        ms       = ms,
+        fl       = nil,
+        has_scan = false
+    }
+
+    return { success = true, scan_name = name }
+end
+
+local function cmd_persistent_scan_first_scan(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local name        = params.name
+    local value       = params.value
+    local vtype       = params.type or "dword"
+    local scan_option = params.scan_option or "exact"
+
+    if not name  then return { success = false, error = "No name provided",  error_code = "INVALID_PARAMS" } end
+    if not value then return { success = false, error = "No value provided", error_code = "INVALID_PARAMS" } end
+
+    local entry = serverState.persistent_scans[name]
+    if not entry then
+        return { success = false, error = "Scan '" .. name .. "' not found. Call create_persistent_scan first.", error_code = "INVALID_PARAMS" }
+    end
+
+    local ms        = entry.ms
+    local varType   = resolveVarType(vtype)
+    local scanOpt   = resolveScanOption(scan_option)
+
+    local fsOk, fsMsg = pcall(function()
+        ms.firstScan(scanOpt, varType, rtRounded, tostring(value), nil,
+                     0, 0x7FFFFFFFFFFFFFFF, "+W-C", fsmNotAligned, "1",
+                     false, false, false, false)
+        ms.waitTillDone()
+    end)
+    if not fsOk then
+        return { success = false, error = "firstScan failed: " .. tostring(fsMsg), error_code = "SCAN_ERROR" }
+    end
+
+    if entry.fl then pcall(function() entry.fl.destroy() end) end
+    local fl
+    local flOk, flMsg = pcall(function()
+        fl = createFoundList(ms)
+        fl.initialize()
+    end)
+    if not flOk then
+        return { success = false, error = "createFoundList failed: " .. tostring(flMsg), error_code = "SCAN_ERROR" }
+    end
+
+    entry.fl       = fl
+    entry.has_scan = true
+
+    return { success = true, scan_name = name, count = fl.getCount() }
+end
+
+local function cmd_persistent_scan_next_scan(params)
+    local ok, err = requireProcess()
+    if not ok then return err end
+
+    local name        = params.name
+    local value       = params.value
+    local scan_option = params.scan_option or "exact"
+
+    if not name then return { success = false, error = "No name provided", error_code = "INVALID_PARAMS" } end
+
+    local entry = serverState.persistent_scans[name]
+    if not entry then
+        return { success = false, error = "Scan '" .. name .. "' not found.", error_code = "INVALID_PARAMS" }
+    end
+    if not entry.has_scan then
+        return { success = false, error = "No first scan done for '" .. name .. "'. Call persistent_scan_first_scan first.", error_code = "INVALID_PARAMS" }
+    end
+
+    local ms      = entry.ms
+    local scanOpt = resolveScanOption(scan_option)
+
+    local nsOk, nsMsg = pcall(function()
+        if scanOpt == soExactValue or scanOpt == soValueBetween or scanOpt == soBiggerThan or scanOpt == soSmallerThan then
+            ms.nextScan(scanOpt, rtRounded, tostring(value or ""), nil, false, false, false, false, false)
+        else
+            ms.nextScan(scanOpt, rtRounded, nil, nil, false, false, false, false, false)
+        end
+        ms.waitTillDone()
+    end)
+    if not nsOk then
+        return { success = false, error = "nextScan failed: " .. tostring(nsMsg), error_code = "SCAN_ERROR" }
+    end
+
+    if entry.fl then pcall(function() entry.fl.destroy() end) end
+    local fl
+    local flOk, flMsg = pcall(function()
+        fl = createFoundList(ms)
+        fl.initialize()
+    end)
+    if not flOk then
+        return { success = false, error = "createFoundList failed: " .. tostring(flMsg), error_code = "SCAN_ERROR" }
+    end
+
+    entry.fl = fl
+
+    return { success = true, scan_name = name, count = fl.getCount() }
+end
+
+local function cmd_persistent_scan_get_results(params)
+    local name   = params.name
+    local offset = params.offset or 0
+    local limit  = params.limit  or 100
+
+    if not name then return { success = false, error = "No name provided", error_code = "INVALID_PARAMS" } end
+
+    local entry = serverState.persistent_scans[name]
+    if not entry then
+        return { success = false, error = "Scan '" .. name .. "' not found.", error_code = "INVALID_PARAMS" }
+    end
+    if not entry.fl then
+        return { success = false, error = "No results for '" .. name .. "'. Run first_scan first.", error_code = "INVALID_PARAMS" }
+    end
+
+    local fl      = entry.fl
+    local total   = fl.getCount()
+    local results = {}
+
+    local stop = math.min(offset + limit - 1, total - 1)
+    for i = offset, stop do
+        local addrStr = fl.getAddress(i)
+        if addrStr and not addrStr:match("^0[xX]") then
+            addrStr = "0x" .. addrStr
+        end
+        table.insert(results, {
+            address = addrStr,
+            value   = fl.getValue(i)
+        })
+    end
+
+    return {
+        success   = true,
+        scan_name = name,
+        total     = total,
+        offset    = offset,
+        limit     = limit,
+        results   = results
+    }
+end
+
+local function cmd_persistent_scan_destroy(params)
+    local name = params.name
+    if not name then return { success = false, error = "No name provided", error_code = "INVALID_PARAMS" } end
+
+    local entry = serverState.persistent_scans[name]
+    if not entry then
+        return { success = false, error = "Scan '" .. name .. "' not found.", error_code = "INVALID_PARAMS" }
+    end
+
+    if entry.fl then pcall(function() entry.fl.destroy() end) end
+    pcall(function() entry.ms.destroy() end)
+    serverState.persistent_scans[name] = nil
+
+    return { success = true, scan_name = name, destroyed = true }
+end
+
+-- >>> END UNIT-15 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2524,17 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Unit 15: Advanced Scanning
+    aob_scan_unique           = cmd_aob_scan_unique,
+    aob_scan_module           = cmd_aob_scan_module,
+    aob_scan_module_unique    = cmd_aob_scan_module_unique,
+    pointer_rescan            = cmd_pointer_rescan,
+    create_persistent_scan    = cmd_create_persistent_scan,
+    persistent_scan_first_scan    = cmd_persistent_scan_first_scan,
+    persistent_scan_next_scan     = cmd_persistent_scan_next_scan,
+    persistent_scan_get_results   = cmd_persistent_scan_get_results,
+    persistent_scan_destroy       = cmd_persistent_scan_destroy,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,88 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- UNIT 15: ADVANCED SCANNING ---
+
+@mcp.tool()
+def aob_scan_unique(pattern: str, protection: str = "+X") -> str:
+    """Scan for an AOB pattern that must match exactly once. Returns {success, address} or error with count.
+    Use this when you expect a signature to be unique in the process."""
+    return format_result(ce_client.send_command("aob_scan_unique", {"pattern": pattern, "protection": protection}))
+
+@mcp.tool()
+def aob_scan_module(pattern: str, module_name: str, protection: str = "+X") -> str:
+    """Scan for an AOB pattern restricted to a specific module's memory range.
+    Returns {success, count, addresses: [str]}."""
+    return format_result(ce_client.send_command("aob_scan_module", {
+        "pattern": pattern,
+        "module_name": module_name,
+        "protection": protection
+    }))
+
+@mcp.tool()
+def aob_scan_module_unique(pattern: str, module_name: str, protection: str = "+X") -> str:
+    """Scan for an AOB pattern in a specific module that must match exactly once.
+    Returns {success, address} or error with count."""
+    return format_result(ce_client.send_command("aob_scan_module_unique", {
+        "pattern": pattern,
+        "module_name": module_name,
+        "protection": protection
+    }))
+
+@mcp.tool()
+def pointer_rescan(value: str, previous_results_file: str = None) -> str:
+    """Re-scan an existing pointer scan for a new value. Requires a prior pointer scan in CE.
+    Returns {success, result_count}. Run a Pointer Scanner scan in CE first."""
+    params = {"value": value}
+    if previous_results_file:
+        params["previous_results_file"] = previous_results_file
+    return format_result(ce_client.send_command("pointer_rescan", params))
+
+@mcp.tool()
+def create_persistent_scan(name: str) -> str:
+    """Create a named, stateful memory scan session. Use the name with persistent_scan_* tools.
+    Returns {success, scan_name}."""
+    return format_result(ce_client.send_command("create_persistent_scan", {"name": name}))
+
+@mcp.tool()
+def persistent_scan_first_scan(name: str, value: str, type: str = "dword", scan_option: str = "exact") -> str:
+    """Run the first scan on a named persistent scan session.
+    Types: byte, word, dword, qword, float, double, string.
+    Scan options: exact, unknown, between, bigger, smaller.
+    Returns {success, scan_name, count}."""
+    return format_result(ce_client.send_command("persistent_scan_first_scan", {
+        "name": name,
+        "value": value,
+        "type": type,
+        "scan_option": scan_option
+    }))
+
+@mcp.tool()
+def persistent_scan_next_scan(name: str, value: str = None, scan_option: str = "exact") -> str:
+    """Narrow down results with a next scan on a named persistent scan session.
+    Scan options: exact, increased, decreased, changed, unchanged, bigger, smaller.
+    Returns {success, scan_name, count}."""
+    params = {"name": name, "scan_option": scan_option}
+    if value is not None:
+        params["value"] = value
+    return format_result(ce_client.send_command("persistent_scan_next_scan", params))
+
+@mcp.tool()
+def persistent_scan_get_results(name: str, offset: int = 0, limit: int = 100) -> str:
+    """Get paginated results from a named persistent scan session.
+    Returns {success, total, offset, limit, results: [{address, value}]}."""
+    return format_result(ce_client.send_command("persistent_scan_get_results", {
+        "name": name,
+        "offset": offset,
+        "limit": limit
+    }))
+
+@mcp.tool()
+def persistent_scan_destroy(name: str) -> str:
+    """Destroy a named persistent scan session and free its memory.
+    Returns {success, scan_name, destroyed}."""
+    return format_result(ce_client.send_command("persistent_scan_destroy", {"name": name}))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
9 new MCP tools for advanced scanning:
- `aob_scan_unique` / `aob_scan_module` / `aob_scan_module_unique` — pattern-scan variants with module-range filtering and unique-match enforcement.
- `pointer_rescan` — re-evaluates a previous pointer scan against current memory.
- `create_persistent_scan` + companion tools (`first_scan`, `next_scan`, `get_results`, `destroy`) — stateful scans stored in `serverState.persistent_scans`, allowing multi-step value-change tracking across multiple MCP calls.

## Unit
Unit 15 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)