### PR TITLE
feat(unit-16): window enumeration and GUI dialog tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,192 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-16 Window GUI <<<
+-- ============================================================================
+-- WINDOW / GUI COMMAND HANDLERS
+-- No process guard required: these APIs are system-wide window operations.
+-- ============================================================================
+
+-- Shared helper: parse a hex window-handle string into a number.
+-- Returns the number, or nil if the string is missing/invalid.
+local function parseHandle(hexStr)
+    return tonumber(hexStr, 16)
+end
+
+local function cmd_find_window(params)
+    local title      = params.title
+    local class_name = params.class_name
+
+    if not title and not class_name then
+        return { success = false, error = "At least one of title or class_name must be provided" }
+    end
+
+    local ok, handle = pcall(function()
+        return findWindow(class_name, title)
+    end)
+
+    if not ok then
+        return { success = false, error = tostring(handle) }
+    end
+
+    if not handle or handle == 0 then
+        return { success = false, error_code = "NOT_FOUND" }
+    end
+
+    return { success = true, handle = toHex(handle) }
+end
+
+local function cmd_get_window_caption(params)
+    local handle = parseHandle(params.handle)
+    if not handle then
+        return { success = false, error = "Invalid handle" }
+    end
+
+    local ok, caption = pcall(function()
+        return getWindowCaption(handle)
+    end)
+
+    if not ok then
+        return { success = false, error = tostring(caption) }
+    end
+
+    return { success = true, caption = caption or "" }
+end
+
+local function cmd_get_window_class_name(params)
+    local handle = parseHandle(params.handle)
+    if not handle then
+        return { success = false, error = "Invalid handle" }
+    end
+
+    local ok, cls = pcall(function()
+        return getWindowClassName(handle)
+    end)
+
+    if not ok then
+        return { success = false, error = tostring(cls) }
+    end
+
+    return { success = true, class_name = cls or "" }
+end
+
+local function cmd_get_window_process_id(params)
+    local handle = parseHandle(params.handle)
+    if not handle then
+        return { success = false, error = "Invalid handle" }
+    end
+
+    local ok, pid = pcall(function()
+        return getWindowProcessID(handle)
+    end)
+
+    if not ok then
+        return { success = false, error = tostring(pid) }
+    end
+
+    return { success = true, process_id = pid }
+end
+
+local function cmd_send_window_message(params)
+    local handle = parseHandle(params.handle)
+    if not handle then
+        return { success = false, error = "Invalid handle" }
+    end
+
+    local msg    = params.msg    or 0
+    local wparam = params.wparam or 0
+    local lparam = params.lparam or 0
+
+    local ok, result = pcall(function()
+        return sendMessage(handle, msg, wparam, lparam)
+    end)
+
+    if not ok then
+        return { success = false, error = tostring(result) }
+    end
+
+    return { success = true, result = result or 0 }
+end
+
+-- Modal dialog — blocks the CE main thread until the user clicks OK.
+local function cmd_show_message(params)
+    local message = params.message
+    if not message then
+        return { success = false, error = "message is required" }
+    end
+
+    local ok, err = pcall(function()
+        showMessage(message)
+    end)
+
+    if not ok then
+        return { success = false, error = tostring(err) }
+    end
+
+    return { success = true }
+end
+
+-- Modal dialog — blocks until the user submits or cancels.
+local function cmd_input_query(params)
+    local caption = params.caption or ""
+    local prompt  = params.prompt  or ""
+    local default = params.default or ""
+
+    local ok, value = pcall(function()
+        return inputQuery(caption, prompt, default)
+    end)
+
+    if not ok then
+        return { success = false, error = tostring(value) }
+    end
+
+    -- inputQuery returns nil on cancel (CE contract)
+    if value == nil then
+        return { success = true, value = "", cancelled = true }
+    end
+
+    return { success = true, value = value, cancelled = false }
+end
+
+-- Modal dialog — blocks until the user selects an item or cancels.
+local function cmd_show_selection_list(params)
+    local caption = params.caption or ""
+    local prompt  = params.prompt  or ""
+    local options = params.options
+
+    if type(options) ~= "table" then
+        return { success = false, error = "options must be a list of strings" }
+    end
+
+    local sl = createStringlist()
+    for _, v in ipairs(options) do
+        sl.add(tostring(v))
+    end
+
+    local ok, idx, selected = pcall(function()
+        return showSelectionList(caption, prompt, sl)
+    end)
+
+    sl.destroy()
+
+    if not ok then
+        return { success = false, error = tostring(idx) }
+    end
+
+    if idx == nil or idx < 0 then
+        return { success = true, selected_index = -1, selected_value = "", cancelled = true }
+    end
+
+    return {
+        success        = true,
+        selected_index = idx,
+        selected_value = selected or "",
+        cancelled      = false
+    }
+end
+
+-- >>> END UNIT-16 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2317,16 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Window / GUI (Unit-16)
+    find_window             = cmd_find_window,
+    get_window_caption      = cmd_get_window_caption,
+    get_window_class_name   = cmd_get_window_class_name,
+    get_window_process_id   = cmd_get_window_process_id,
+    send_window_message     = cmd_send_window_message,
+    show_message            = cmd_show_message,
+    input_query             = cmd_input_query,
+    show_selection_list     = cmd_show_selection_list,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,102 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- WINDOW / GUI TOOLS (Unit-16) ---
+
+@mcp.tool()
+def find_window(title: str = None, class_name: str = None) -> str:
+    """Find a top-level window by title and/or class name (system-wide, no process required).
+
+    At least one of title or class_name must be provided.
+    Returns {success, handle} on success or {success=false, error_code="NOT_FOUND"} when
+    no matching window exists.
+    """
+    params = {}
+    if title is not None:
+        params["title"] = title
+    if class_name is not None:
+        params["class_name"] = class_name
+    return format_result(ce_client.send_command("find_window", params))
+
+@mcp.tool()
+def get_window_caption(handle: str) -> str:
+    """Return the caption (title bar text) of a window given its handle (hex string)."""
+    return format_result(ce_client.send_command("get_window_caption", {"handle": handle}))
+
+@mcp.tool()
+def get_window_class_name(handle: str) -> str:
+    """Return the window class name of a window given its handle (hex string)."""
+    return format_result(ce_client.send_command("get_window_class_name", {"handle": handle}))
+
+@mcp.tool()
+def get_window_process_id(handle: str) -> str:
+    """Return the process ID that owns a window given its handle (hex string)."""
+    return format_result(ce_client.send_command("get_window_process_id", {"handle": handle}))
+
+@mcp.tool()
+def send_window_message(handle: str, msg: int, wparam: int = 0, lparam: int = 0) -> str:
+    """Send a Windows message (WM_*) to a window.
+
+    handle  -- hex window handle string
+    msg     -- message ID (e.g. 0x000F for WM_PAINT)
+    wparam  -- WPARAM value (default 0)
+    lparam  -- LPARAM value (default 0)
+
+    Returns {success, result} where result is the integer return value of SendMessage.
+    """
+    return format_result(ce_client.send_command("send_window_message", {
+        "handle": handle,
+        "msg": msg,
+        "wparam": wparam,
+        "lparam": lparam,
+    }))
+
+@mcp.tool()
+def show_message(message: str) -> str:
+    """Show a modal message dialog in Cheat Engine.
+
+    WARNING — NOT SAFE FOR AUTOMATED WORKFLOWS:
+    This call BLOCKS the CE main thread until the user dismisses the dialog by
+    clicking OK.  Do not invoke from automation that expects a timely response.
+
+    Returns {success} after the user closes the dialog.
+    """
+    return format_result(ce_client.send_command("show_message", {"message": message}))
+
+@mcp.tool()
+def input_query(caption: str, prompt: str, default: str = "") -> str:
+    """Show a modal text-input dialog in Cheat Engine and return what the user typed.
+
+    WARNING — NOT SAFE FOR AUTOMATED WORKFLOWS:
+    This call BLOCKS the CE main thread until the user submits or cancels the dialog.
+    Do not invoke from automation that expects a timely response.
+
+    Returns {success, value, cancelled}.  If cancelled is true, value is an empty string.
+    """
+    return format_result(ce_client.send_command("input_query", {
+        "caption": caption,
+        "prompt": prompt,
+        "default": default,
+    }))
+
+@mcp.tool()
+def show_selection_list(caption: str, prompt: str, options: list) -> str:
+    """Show a modal list-selection dialog in Cheat Engine.
+
+    WARNING — NOT SAFE FOR AUTOMATED WORKFLOWS:
+    This call BLOCKS the CE main thread until the user picks an item or cancels.
+    Do not invoke from automation that expects a timely response.
+
+    options -- list of strings to display
+    Returns {success, selected_index, selected_value, cancelled}.
+    selected_index is -1 and cancelled is true when the user dismisses without selecting.
+    """
+    return format_result(ce_client.send_command("show_selection_list", {
+        "caption": caption,
+        "prompt": prompt,
+        "options": options,
+    }))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
8 new MCP tools:
- `find_window` / `get_window_caption` / `get_window_class_name` / `get_window_process_id` — Windows window enumeration.
- `send_window_message` — Windows SendMessage wrapper.
- `show_message` / `input_query` / `show_selection_list` — modal CE dialogs (**BLOCK** waiting for user click, flagged in docstrings).

Shared `parseHandle()` helper eliminates the hex-to-handle copy-paste across the four handle-taking commands.

## Unit
Unit 16 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)