### PR TITLE
feat(unit-17): mouse, keyboard, and screen automation tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,104 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-17 Input Automation <<<
+-- ============================================================================
+-- COMMAND HANDLERS - INPUT AUTOMATION (mouse, keyboard, screen)
+-- These APIs operate system-wide and require NO attached process.
+-- ============================================================================
+
+-- Shared helpers (local to this section)
+local function parse_xy(params)
+    if params.x == nil then return nil, nil, "Missing parameter: x" end
+    if params.y == nil then return nil, nil, "Missing parameter: y" end
+    local x, y = tonumber(params.x), tonumber(params.y)
+    if x == nil or y == nil then return nil, nil, "Parameters x and y must be numbers" end
+    return x, y, nil
+end
+
+local function parse_vk(params)
+    if params.vk == nil then return nil, "Missing parameter: vk (Windows virtual-key code, e.g. 0x41 for 'A')" end
+    local vk = tonumber(params.vk)
+    if vk == nil then return nil, "Parameter vk must be a number" end
+    return vk, nil
+end
+
+-- Execute a no-return CE key API (keyDown / keyUp / doKeyPress) and return {success}.
+local function run_key_action(fn, vk, fn_name)
+    local ok, err = pcall(fn, vk)
+    if not ok then return { success = false, error = fn_name .. " failed: " .. tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_get_pixel(params)
+    local x, y, err = parse_xy(params)
+    if err then return { success = false, error = err } end
+
+    local ok, rgb = pcall(getPixel, x, y)
+    if not ok then return { success = false, error = "getPixel failed: " .. tostring(rgb) } end
+    -- Windows COLORREF format: 0x00BBGGRR
+    local r = rgb % 256
+    local g = math.floor(rgb / 256) % 256
+    local b = math.floor(rgb / 65536) % 256
+    return { success = true, r = r, g = g, b = b, rgb = rgb }
+end
+
+local function cmd_get_mouse_pos(params)
+    local ok, x, y = pcall(getMousePos)
+    if not ok then return { success = false, error = "getMousePos failed: " .. tostring(x) } end
+    return { success = true, x = x, y = y }
+end
+
+local function cmd_set_mouse_pos(params)
+    local x, y, err = parse_xy(params)
+    if err then return { success = false, error = err } end
+
+    local ok, e = pcall(setMousePos, x, y)
+    if not ok then return { success = false, error = "setMousePos failed: " .. tostring(e) } end
+    return { success = true }
+end
+
+local function cmd_is_key_pressed(params)
+    local vk, err = parse_vk(params)
+    if err then return { success = false, error = err } end
+
+    local ok, pressed = pcall(isKeyPressed, vk)
+    if not ok then return { success = false, error = "isKeyPressed failed: " .. tostring(pressed) } end
+    return { success = true, pressed = pressed == true }
+end
+
+local function cmd_key_down(params)
+    local vk, err = parse_vk(params)
+    if err then return { success = false, error = err } end
+    return run_key_action(keyDown, vk, "keyDown")
+end
+
+local function cmd_key_up(params)
+    local vk, err = parse_vk(params)
+    if err then return { success = false, error = err } end
+    return run_key_action(keyUp, vk, "keyUp")
+end
+
+local function cmd_do_key_press(params)
+    local vk, err = parse_vk(params)
+    if err then return { success = false, error = err } end
+    return run_key_action(doKeyPress, vk, "doKeyPress")
+end
+
+local function cmd_get_screen_info(params)
+    local ok_w, width  = pcall(getScreenWidth)
+    local ok_h, height = pcall(getScreenHeight)
+    local ok_d, dpi    = pcall(getScreenDPI)
+
+    if not ok_w then return { success = false, error = "getScreenWidth failed: " .. tostring(width) } end
+    if not ok_h then return { success = false, error = "getScreenHeight failed: " .. tostring(height) } end
+    if not ok_d then return { success = false, error = "getScreenDPI failed: " .. tostring(dpi) } end
+
+    return { success = true, width = width, height = height, dpi = dpi }
+end
+
+-- >>> END UNIT-17 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2129,6 +2227,16 @@ local commandHandlers = {
     find_what_accesses_safe = cmd_start_dbvm_watch,  -- Alias: start watching for accesses
     get_watch_results = cmd_stop_dbvm_watch,  -- Alias: retrieve results and stop
     
+    -- Input Automation (Unit-17) — system-wide, no process guard required
+    get_pixel = cmd_get_pixel,
+    get_mouse_pos = cmd_get_mouse_pos,
+    set_mouse_pos = cmd_set_mouse_pos,
+    is_key_pressed = cmd_is_key_pressed,
+    key_down = cmd_key_down,
+    key_up = cmd_key_up,
+    do_key_press = cmd_do_key_press,
+    get_screen_info = cmd_get_screen_info,
+
     -- Utility
     ping = cmd_ping,
 }

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,53 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- INPUT AUTOMATION (Unit-17) — system-wide, no process guard required ---
+
+@mcp.tool()
+def get_pixel(x: int, y: int) -> str:
+    """Get the colour of a screen pixel at (x, y). Returns r, g, b channels and the raw COLORREF integer."""
+    return format_result(ce_client.send_command("get_pixel", {"x": x, "y": y}))
+
+@mcp.tool()
+def get_mouse_pos() -> str:
+    """Get the current mouse cursor position. Returns x and y screen coordinates."""
+    return format_result(ce_client.send_command("get_mouse_pos"))
+
+@mcp.tool()
+def set_mouse_pos(x: int, y: int) -> str:
+    """Move the mouse cursor to screen position (x, y)."""
+    return format_result(ce_client.send_command("set_mouse_pos", {"x": x, "y": y}))
+
+@mcp.tool()
+def is_key_pressed(vk: int) -> str:
+    """Check whether a key is currently held down.
+    vk is a Windows virtual-key code (e.g. 0x41 for 'A', 0x20 for Space, 0x01 for left mouse button).
+    Returns pressed: bool."""
+    return format_result(ce_client.send_command("is_key_pressed", {"vk": vk}))
+
+@mcp.tool()
+def key_down(vk: int) -> str:
+    """Simulate pressing a key down (does NOT release it automatically).
+    vk is a Windows virtual-key code (e.g. 0x41 for 'A', 0x20 for Space)."""
+    return format_result(ce_client.send_command("key_down", {"vk": vk}))
+
+@mcp.tool()
+def key_up(vk: int) -> str:
+    """Release a key that was pressed with key_down.
+    vk is a Windows virtual-key code (e.g. 0x41 for 'A', 0x20 for Space)."""
+    return format_result(ce_client.send_command("key_up", {"vk": vk}))
+
+@mcp.tool()
+def do_key_press(vk: int) -> str:
+    """Simulate a full key press (down + up) for the given key.
+    vk is a Windows virtual-key code (e.g. 0x41 for 'A', 0x20 for Space)."""
+    return format_result(ce_client.send_command("do_key_press", {"vk": vk}))
+
+@mcp.tool()
+def get_screen_info() -> str:
+    """Get the primary screen dimensions and DPI. Returns width, height (pixels) and dpi."""
+    return format_result(ce_client.send_command("get_screen_info"))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
8 new MCP tools wrapping CE's system-wide mouse/keyboard/screen APIs (no process guard needed):
- `get_pixel` — screen pixel sample (r/g/b split from COLORREF).
- `get_mouse_pos` / `set_mouse_pos`.
- `is_key_pressed` / `key_down` / `key_up` / `do_key_press` — Windows virtual-key codes.
- `get_screen_info` — composite width/height/DPI.

Extracted `parse_xy`, `parse_vk`, `run_key_action` helpers. Fixed a subtle correctness bug: the original coord validation rejected `0` as falsy — now uses explicit nil check after `tonumber`.

## Unit
Unit 17 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)