### PR TITLE
feat(unit-18): cheat table load/save and memory record management

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,275 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-18 Cheat Table Records <<<
+
+local UNIT18_TYPE_MAP = {
+    byte      = "vtByte",
+    word      = "vtWord",
+    dword     = "vtDword",
+    qword     = "vtQword",
+    float     = "vtSingle",
+    single    = "vtSingle",
+    double    = "vtDouble",
+    string    = "vtString",
+    bytearray = "vtByteArray",
+    aob       = "vtByteArray",
+}
+
+-- Returns (al, nil) on success or (nil, error-response-table) on failure.
+local function unit18_get_al()
+    local ok, al = pcall(getAddressList)
+    if not ok or not al then
+        return nil, { success = false, error = "Cannot get AddressList", error_code = "CE_API_UNAVAILABLE" }
+    end
+    return al, nil
+end
+
+-- Returns (rec, nil) on success or (nil, error-response-table) when not found.
+local function unit18_get_rec_by_id(al, id)
+    local ok, rec = pcall(function() return al:getMemoryRecordByID(id) end)
+    if not ok or not rec then
+        return nil, { success = false, error = "Memory record not found", error_code = "NOT_FOUND" }
+    end
+    return rec, nil
+end
+
+-- Validates a table-file path: non-empty string, no directory traversal.
+local function unit18_check_filename(filename)
+    if type(filename) ~= "string" or filename == "" then
+        return { success = false, error = "filename required", error_code = "INVALID_PARAMS" }
+    end
+    if filename:find("%.%.") then
+        return { success = false, error = "Path traversal not allowed", error_code = "INVALID_PARAMS" }
+    end
+end
+
+local function unit18_rec_to_table(rec)
+    if not rec then return nil end
+
+    local function prop(name)
+        local ok, v = pcall(function() return rec[name] end)
+        return ok and v or nil
+    end
+
+    local offsetCount = prop("OffsetCount") or 0
+    local offsets = {}
+    for i = 0, offsetCount - 1 do
+        local ok, off = pcall(function() return rec.Offset[i] end)
+        table.insert(offsets, ok and off or nil)
+    end
+
+    return {
+        id          = prop("ID"),
+        description = prop("Description") or "",
+        address     = prop("Address")     or "",
+        type        = prop("VarType")     or "",
+        value       = prop("Value")       or "",
+        offsets     = offsets,
+        enabled     = prop("Active")      or false,
+    }
+end
+
+local function cmd_load_table(params)
+    local filename = params.filename
+    local err = unit18_check_filename(filename)
+    if err then return err end
+
+    local ok, cerr = pcall(loadTable, filename, params.merge or false)
+    if not ok then
+        return { success = false, error = tostring(cerr), error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true }
+end
+
+local function cmd_save_table(params)
+    local filename = params.filename
+    local err = unit18_check_filename(filename)
+    if err then return err end
+
+    local ok, cerr = pcall(saveTable, filename, params.protect or false)
+    if not ok then
+        return { success = false, error = tostring(cerr), error_code = "INTERNAL_ERROR" }
+    end
+    return { success = true }
+end
+
+local function cmd_get_address_list(params)
+    local offset = params.offset or 0
+    local limit  = params.limit  or 100
+
+    local al, aerr = unit18_get_al()
+    if not al then return aerr end
+
+    local okC, count = pcall(function() return al.Count end)
+    if not okC then count = 0 end
+
+    local records = {}
+    local returned = 0
+    for i = offset, math.min(offset + limit - 1, count - 1) do
+        local okR, rec = pcall(function() return al[i] end)
+        if okR and rec then
+            table.insert(records, unit18_rec_to_table(rec))
+            returned = returned + 1
+        end
+    end
+
+    return {
+        success  = true,
+        total    = count,
+        offset   = offset,
+        limit    = limit,
+        returned = returned,
+        records  = records,
+    }
+end
+
+local function cmd_get_memory_record(params)
+    local id   = params.id
+    local desc = params.description
+
+    if id == nil and desc == nil then
+        return { success = false, error = "id or description required", error_code = "INVALID_PARAMS" }
+    end
+
+    local al, aerr = unit18_get_al()
+    if not al then return aerr end
+
+    local rec
+    if id ~= nil then
+        local ok
+        ok, rec = pcall(function() return al:getMemoryRecordByID(id) end)
+        if not ok then rec = nil end
+    else
+        local ok
+        ok, rec = pcall(function() return al:getMemoryRecordByDescription(desc) end)
+        if not ok then rec = nil end
+    end
+
+    if not rec then
+        return { success = false, error = "Memory record not found", error_code = "NOT_FOUND" }
+    end
+
+    return { success = true, record = unit18_rec_to_table(rec) }
+end
+
+local function cmd_create_memory_record(params)
+    local description = params.description
+    local address     = params.address
+    local typeStr     = string.lower(params.type or "dword")
+
+    if type(description) ~= "string" or description == "" then
+        return { success = false, error = "description required", error_code = "INVALID_PARAMS" }
+    end
+    if type(address) ~= "string" or address == "" then
+        return { success = false, error = "address required", error_code = "INVALID_PARAMS" }
+    end
+
+    local vtName = UNIT18_TYPE_MAP[typeStr]
+    if not vtName then
+        return { success = false, error = "Unknown type: " .. typeStr, error_code = "INVALID_PARAMS" }
+    end
+
+    local al, aerr = unit18_get_al()
+    if not al then return aerr end
+
+    local okC, rec = pcall(function() return al:createMemoryRecord() end)
+    if not okC or not rec then
+        return { success = false, error = tostring(rec), error_code = "INTERNAL_ERROR" }
+    end
+
+    -- Helper: set a property, rolling back the record on failure.
+    local function set_prop(name, val)
+        local ok = pcall(function() rec[name] = val end)
+        if not ok then
+            pcall(function() rec:delete() end)
+            return { success = false, error = "Failed to set " .. name, error_code = "INTERNAL_ERROR" }
+        end
+    end
+
+    local perr = set_prop("Description", description)
+    if perr then return perr end
+
+    perr = set_prop("Address", address)
+    if perr then return perr end
+
+    -- VarType accepts the string constant name; fall back to the global numeric value.
+    if not pcall(function() rec.VarType = vtName end) then
+        pcall(function() rec.VarType = _G[vtName] end)
+    end
+
+    local okId, recId = pcall(function() return rec.ID end)
+    if not okId then recId = nil end
+
+    return { success = true, id = recId, record = unit18_rec_to_table(rec) }
+end
+
+local function cmd_delete_memory_record(params)
+    local id = params.id
+    if id == nil then
+        return { success = false, error = "id required", error_code = "INVALID_PARAMS" }
+    end
+
+    local al, aerr = unit18_get_al()
+    if not al then return aerr end
+
+    local rec, rerr = unit18_get_rec_by_id(al, id)
+    if not rec then return rerr end
+
+    local ok, cerr = pcall(function() rec:delete() end)
+    if not ok then
+        return { success = false, error = tostring(cerr), error_code = "INTERNAL_ERROR" }
+    end
+
+    return { success = true }
+end
+
+local function cmd_get_memory_record_value(params)
+    local id = params.id
+    if id == nil then
+        return { success = false, error = "id required", error_code = "INVALID_PARAMS" }
+    end
+
+    local al, aerr = unit18_get_al()
+    if not al then return aerr end
+
+    local rec, rerr = unit18_get_rec_by_id(al, id)
+    if not rec then return rerr end
+
+    local ok, value = pcall(function() return rec.Value end)
+    if not ok then
+        return { success = false, error = tostring(value), error_code = "INTERNAL_ERROR" }
+    end
+
+    return { success = true, value = tostring(value or "") }
+end
+
+local function cmd_set_memory_record_value(params)
+    local id    = params.id
+    local value = params.value
+    if id == nil then
+        return { success = false, error = "id required", error_code = "INVALID_PARAMS" }
+    end
+    if value == nil then
+        return { success = false, error = "value required", error_code = "INVALID_PARAMS" }
+    end
+
+    local al, aerr = unit18_get_al()
+    if not al then return aerr end
+
+    local rec, rerr = unit18_get_rec_by_id(al, id)
+    if not rec then return rerr end
+
+    local ok, cerr = pcall(function() rec.Value = tostring(value) end)
+    if not ok then
+        return { success = false, error = tostring(cerr), error_code = "INTERNAL_ERROR" }
+    end
+
+    return { success = true }
+end
+
+-- >>> END UNIT-18 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2400,17 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- >>> BEGIN UNIT-18 dispatcher entries <<<
+    load_table               = cmd_load_table,
+    save_table               = cmd_save_table,
+    get_address_list         = cmd_get_address_list,
+    get_memory_record        = cmd_get_memory_record,
+    create_memory_record     = cmd_create_memory_record,
+    delete_memory_record     = cmd_delete_memory_record,
+    get_memory_record_value  = cmd_get_memory_record_value,
+    set_memory_record_value  = cmd_set_memory_record_value,
+    -- >>> END UNIT-18 <<<
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,115 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# >>> BEGIN UNIT-18 Cheat Table Records <<<
+
+@mcp.tool()
+def load_table(filename: str, merge: bool = False) -> str:
+    """Load a Cheat Engine table (.ct) file into the current session.
+
+    Args:
+        filename: Path to the .ct or .cetrainer file to load.
+        merge: If True, merge with the current table instead of replacing it.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("load_table", {"filename": filename, "merge": merge}))
+
+@mcp.tool()
+def save_table(filename: str, protect: bool = False) -> str:
+    """Save the current cheat table to a file.
+
+    Args:
+        filename: Destination path for the .ct or .cetrainer file.
+        protect: If True and the filename has a .cetrainer extension, protect it from normal reading.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("save_table", {"filename": filename, "protect": protect}))
+
+@mcp.tool()
+def get_address_list(offset: int = 0, limit: int = 100) -> str:
+    """List memory records in the current cheat table's address list.
+
+    Args:
+        offset: Zero-based index of the first record to return.
+        limit: Maximum number of records to return (default 100).
+
+    Returns JSON with: success, total, offset, limit, returned, records (list of
+    {id, description, address, type, value, offsets, enabled}).
+    """
+    return format_result(ce_client.send_command("get_address_list", {"offset": offset, "limit": limit}))
+
+@mcp.tool()
+def get_memory_record(id: int = None, description: str = None) -> str:
+    """Retrieve a single memory record by ID or description.
+
+    Args:
+        id: Unique numeric ID of the memory record.
+        description: Description string of the memory record (used when id is not provided).
+
+    Returns JSON with: success, record ({id, description, address, type, value, offsets, enabled}).
+    """
+    params = {}
+    if id is not None:
+        params["id"] = id
+    if description is not None:
+        params["description"] = description
+    return format_result(ce_client.send_command("get_memory_record", params))
+
+@mcp.tool()
+def create_memory_record(description: str, address: str, var_type: str = "dword") -> str:
+    """Create a new memory record in the cheat table address list.
+
+    Args:
+        description: Human-readable label for the new entry.
+        address: Address string (hex, symbol, or pointer expression) to watch.
+        var_type: Variable type — byte, word, dword, qword, float, double, string, bytearray (default: dword).
+
+    Returns JSON with: success, id, record ({id, description, address, type, value, offsets, enabled}).
+    """
+    return format_result(ce_client.send_command("create_memory_record", {
+        "description": description,
+        "address": address,
+        "type": var_type,
+    }))
+
+@mcp.tool()
+def delete_memory_record(id: int) -> str:
+    """Delete a memory record from the cheat table address list by ID.
+
+    Args:
+        id: Unique numeric ID of the memory record to delete.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("delete_memory_record", {"id": id}))
+
+@mcp.tool()
+def get_memory_record_value(id: int) -> str:
+    """Read the current value of a memory record as a string.
+
+    Args:
+        id: Unique numeric ID of the memory record.
+
+    Returns JSON with: success, value (string representation of the current value).
+    """
+    return format_result(ce_client.send_command("get_memory_record_value", {"id": id}))
+
+@mcp.tool()
+def set_memory_record_value(id: int, value: str) -> str:
+    """Write a value to a memory record (and therefore to the target process memory).
+
+    Args:
+        id: Unique numeric ID of the memory record to update.
+        value: New value as a string (e.g. "100", "3.14", "FF AA BB").
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("set_memory_record_value", {"id": id, "value": value}))
+
+# >>> END UNIT-18 <<<
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
8 new MCP tools for cheat table (.CT) and memory record management:
- `load_table` / `save_table` — cheat table file I/O with filename sanitization.
- `get_address_list` — paginated AddressList enumeration.
- `get_memory_record` / `create_memory_record` / `delete_memory_record` — record CRUD.
- `get_memory_record_value` / `set_memory_record_value` — value access.

Shared helpers: `unit18_get_al`, `unit18_get_rec_by_id`, `unit18_check_filename`. Uses idiomatic Lua colon-call syntax (`al:getMemoryRecordByID(id)`). Python side renames `type` param to `var_type` to avoid shadowing the builtin.

## Unit
Unit 18 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)