### PR TITLE
feat(unit-19): structure definition management tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,249 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-19 Structure Management <<<
+
+serverState.structures = serverState.structures or {}
+serverState.structure_next_id = serverState.structure_next_id or 1
+
+local vartypeMap = {
+    byte      = vtByte,
+    word      = vtWord,
+    dword     = vtDword,
+    qword     = vtQword,
+    float     = vtSingle,
+    single    = vtSingle,
+    double    = vtDouble,
+    string    = vtString,
+    aob       = vtByteArray,
+    bytearray = vtByteArray,
+    pointer   = vtPointer,
+}
+
+-- Constant reverse map; hoisted so it is not reallocated on every call.
+local vtypeNames = {
+    [vtByte]      = "byte",
+    [vtWord]      = "word",
+    [vtDword]     = "dword",
+    [vtQword]     = "qword",
+    [vtSingle]    = "float",
+    [vtDouble]    = "double",
+    [vtString]    = "string",
+    [vtByteArray] = "aob",
+    [vtPointer]   = "pointer",
+}
+
+local function vtypeToString(vt)
+    return vtypeNames[vt] or tostring(vt)
+end
+
+-- Hoisted so it is not re-created on every export call.
+local function xmlEscape(s)
+    s = tostring(s)
+    s = s:gsub("&", "&amp;")
+    s = s:gsub("<", "&lt;")
+    s = s:gsub(">", "&gt;")
+    s = s:gsub('"', "&quot;")
+    s = s:gsub("'", "&apos;")
+    return s
+end
+
+-- Returns structure object on success, or nil + error-result table on failure.
+local function resolveStructure(params)
+    local sid = params.structure_id
+    if not sid then
+        return nil, { success = false, error = "structure_id is required", error_code = "INVALID_PARAMS" }
+    end
+    local structure = serverState.structures[sid]
+    if not structure then
+        return nil, { success = false, error = "Unknown structure_id: " .. tostring(sid), error_code = "NOT_FOUND" }
+    end
+    return structure, nil
+end
+
+-- Reads element properties via pcall-guarded property access.
+local function readElementProps(el)
+    local name, offset, vt, size
+    pcall(function() name   = el.Name    end)
+    pcall(function() offset = el.Offset  end)
+    pcall(function() vt     = el.Vartype end)
+    pcall(function() size   = el.Bytesize end)
+    return name or "", offset or 0, vt, size or 0
+end
+
+local function cmd_create_structure(params)
+    local name = params.name
+    if not name or name == "" then
+        return { success = false, error = "name is required", error_code = "INVALID_PARAMS" }
+    end
+
+    local ok, structure = pcall(createStructure, name)
+    if not ok or not structure then
+        return { success = false, error = "createStructure failed: " .. tostring(structure), error_code = "CE_API_UNAVAILABLE" }
+    end
+
+    local ok2, err2 = pcall(function() structure.addToGlobalStructureList() end)
+    if not ok2 then
+        return { success = false, error = "addToGlobalStructureList failed: " .. tostring(err2), error_code = "CE_API_UNAVAILABLE" }
+    end
+
+    local id = serverState.structure_next_id
+    serverState.structure_next_id = serverState.structure_next_id + 1
+    serverState.structures[id] = structure
+
+    return { success = true, structure_id = id }
+end
+
+local function cmd_get_structure_by_name(params)
+    local name = params.name
+    if not name or name == "" then
+        return { success = false, error = "name is required", error_code = "INVALID_PARAMS" }
+    end
+
+    local ok, count = pcall(getStructureCount)
+    if not ok then
+        return { success = false, error = "getStructureCount failed: " .. tostring(count), error_code = "CE_API_UNAVAILABLE" }
+    end
+
+    for i = 0, count - 1 do
+        local ok2, s = pcall(getStructure, i)
+        if ok2 and s then
+            local ok3, sname = pcall(function() return s.Name end)
+            if ok3 and sname == name then
+                local sid = nil
+                for id, stored in pairs(serverState.structures) do
+                    local ok4, sn = pcall(function() return stored.Name end)
+                    if ok4 and sn == name then sid = id; break end
+                end
+                if not sid then
+                    sid = serverState.structure_next_id
+                    serverState.structure_next_id = serverState.structure_next_id + 1
+                    serverState.structures[sid] = s
+                end
+                local ok5, sz  = pcall(function() return s.Size end)
+                local ok6, cnt = pcall(function() return s.Count end)
+                return {
+                    success       = true,
+                    structure_id  = sid,
+                    name          = name,
+                    element_count = ok6 and cnt or 0,
+                    size          = ok5 and sz  or 0,
+                }
+            end
+        end
+    end
+
+    return { success = false, error = "Structure not found: " .. name, error_code = "NOT_FOUND" }
+end
+
+local function cmd_add_element_to_structure(params)
+    local ename  = params.name
+    local offset = params.offset
+    local etype  = params.type
+
+    local structure, err = resolveStructure(params)
+    if not structure then return err end
+
+    if not ename or offset == nil or not etype then
+        return { success = false, error = "name, offset, type are required", error_code = "INVALID_PARAMS" }
+    end
+
+    local vt = vartypeMap[string.lower(tostring(etype))]
+    if not vt then
+        return { success = false, error = "Unknown type: " .. tostring(etype), error_code = "INVALID_PARAMS" }
+    end
+
+    local ok, element = pcall(function() return structure.addElement() end)
+    if not ok or not element then
+        return { success = false, error = "addElement failed: " .. tostring(element), error_code = "CE_API_UNAVAILABLE" }
+    end
+
+    local ok2, err2 = pcall(function()
+        element.Name    = ename
+        element.Offset  = offset
+        element.Vartype = vt
+    end)
+    if not ok2 then
+        return { success = false, error = "Setting element properties failed: " .. tostring(err2), error_code = "CE_API_UNAVAILABLE" }
+    end
+
+    local ok3, cnt = pcall(function() return structure.Count end)
+    local idx = (ok3 and cnt) and (cnt - 1) or nil
+
+    return { success = true, element_index = idx }
+end
+
+local function cmd_get_structure_elements(params)
+    local structure, err = resolveStructure(params)
+    if not structure then return err end
+
+    local ok, cnt = pcall(function() return structure.Count end)
+    if not ok then
+        return { success = false, error = "Failed to read structure count: " .. tostring(cnt), error_code = "CE_API_UNAVAILABLE" }
+    end
+
+    local elements = {}
+    for i = 0, cnt - 1 do
+        local ok2, el = pcall(function() return structure.getElement(i) end)
+        if ok2 and el then
+            local elName, elOffset, elVt, elSize = readElementProps(el)
+            elements[#elements + 1] = {
+                name   = elName,
+                offset = elOffset,
+                type   = vtypeToString(elVt),
+                size   = elSize,
+            }
+        end
+    end
+
+    return { success = true, structure_id = params.structure_id, elements = elements }
+end
+
+local function cmd_export_structure_to_xml(params)
+    local structure, err = resolveStructure(params)
+    if not structure then return err end
+
+    local ok, sname = pcall(function() return structure.Name end)
+    if not ok then sname = "Unknown" end
+    local ok2, sz  = pcall(function() return structure.Size end)
+    if not ok2 then sz = 0 end
+    local ok3, cnt = pcall(function() return structure.Count end)
+    if not ok3 then cnt = 0 end
+
+    local lines = {}
+    lines[#lines + 1] = '<?xml version="1.0" encoding="utf-8"?>'
+    lines[#lines + 1] = string.format('<Structure Name="%s" Size="%d">', xmlEscape(sname), sz)
+
+    for i = 0, cnt - 1 do
+        local ok4, el = pcall(function() return structure.getElement(i) end)
+        if ok4 and el then
+            local elName, elOffset, elVt, elSize = readElementProps(el)
+            lines[#lines + 1] = string.format(
+                '  <Element Name="%s" Offset="%d" Type="%s" Size="%d"/>',
+                xmlEscape(elName), elOffset, xmlEscape(vtypeToString(elVt)), elSize
+            )
+        end
+    end
+
+    lines[#lines + 1] = '</Structure>'
+
+    return { success = true, xml = table.concat(lines, "\n") }
+end
+
+local function cmd_delete_structure(params)
+    local structure, err = resolveStructure(params)
+    if not structure then return err end
+
+    pcall(function() structure.removeFromGlobalStructureList() end)
+    pcall(function() structure.destroy() end)
+
+    serverState.structures[params.structure_id] = nil
+
+    return { success = true }
+end
+
+-- >>> END UNIT-19 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2374,15 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- >>> BEGIN UNIT-19 dispatcher entries <<<
+    create_structure           = cmd_create_structure,
+    get_structure_by_name      = cmd_get_structure_by_name,
+    add_element_to_structure   = cmd_add_element_to_structure,
+    get_structure_elements     = cmd_get_structure_elements,
+    export_structure_to_xml    = cmd_export_structure_to_xml,
+    delete_structure           = cmd_delete_structure,
+    -- >>> END UNIT-19 <<<
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,90 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# >>> BEGIN UNIT-19 Structure Management <<<
+
+@mcp.tool()
+def create_structure(name: str) -> str:
+    """Create a new empty CE structure definition and add it to the global list.
+
+    Args:
+        name: The name for the new structure.
+
+    Returns JSON with: success, structure_id.
+    """
+    return format_result(ce_client.send_command("create_structure", {"name": name}))
+
+
+@mcp.tool()
+def get_structure_by_name(name: str) -> str:
+    """Find a CE structure by name in the global structure list.
+
+    Args:
+        name: The structure name to search for.
+
+    Returns JSON with: success, structure_id, name, element_count, size.
+    """
+    return format_result(ce_client.send_command("get_structure_by_name", {"name": name}))
+
+
+@mcp.tool()
+def add_element_to_structure(structure_id: int, name: str, offset: int, type: str) -> str:
+    """Add a new element to an existing CE structure.
+
+    Args:
+        structure_id: The structure ID returned by create_structure or get_structure_by_name.
+        name: The element name.
+        offset: The byte offset of the element within the structure.
+        type: The variable type. Accepted values: byte, word, dword, qword,
+              float, single, double, string, aob, bytearray, pointer.
+
+    Returns JSON with: success, element_index.
+    """
+    return format_result(ce_client.send_command("add_element_to_structure", {
+        "structure_id": structure_id,
+        "name": name,
+        "offset": offset,
+        "type": type,
+    }))
+
+
+@mcp.tool()
+def get_structure_elements(structure_id: int) -> str:
+    """Get all elements of a CE structure.
+
+    Args:
+        structure_id: The structure ID.
+
+    Returns JSON with: success, structure_id, elements (list of {name, offset, type, size}).
+    """
+    return format_result(ce_client.send_command("get_structure_elements", {"structure_id": structure_id}))
+
+
+@mcp.tool()
+def export_structure_to_xml(structure_id: int) -> str:
+    """Export a CE structure definition as XML.
+
+    Args:
+        structure_id: The structure ID.
+
+    Returns JSON with: success, xml (XML string representation of the structure).
+    """
+    return format_result(ce_client.send_command("export_structure_to_xml", {"structure_id": structure_id}))
+
+
+@mcp.tool()
+def delete_structure(structure_id: int) -> str:
+    """Delete a CE structure from the global list and free it.
+
+    Args:
+        structure_id: The structure ID to delete.
+
+    Returns JSON with: success.
+    """
+    return format_result(ce_client.send_command("delete_structure", {"structure_id": structure_id}))
+
+# >>> END UNIT-19 <<<
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
6 new MCP tools for CE structure definitions:
- `create_structure` / `delete_structure` — lifecycle.
- `get_structure_by_name` — iterate `getStructureCount()` for lookup.
- `add_element_to_structure` — create and configure structure elements.
- `get_structure_elements` — enumerate elements (name/offset/type/size).
- `export_structure_to_xml` — XML serialization.

Helpers: `resolveStructure` (5-line lookup dedupe across 4 functions), `readElementProps` (element property extraction). Hoisted `vtypeNames` and `xmlEscape` to module scope.

## Unit
Unit 19 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)