### PR TITLE
feat(unit-20a): safe file I/O and clipboard tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,100 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-20a File IO Clipboard <<<
+-- ============================================================================
+-- UNIT-20a: Safe File I/O and Clipboard Tools
+-- ============================================================================
+
+local function sanitizeFilename(f)
+    if type(f) ~= "string" or f == "" then return nil, "Invalid filename" end
+    if f:find("%.%.") then return nil, "Path traversal not allowed" end
+    return f, nil
+end
+
+local function cmd_file_exists(params)
+    local filename = params.filename
+    local f, err = sanitizeFilename(filename)
+    if not f then return { success = false, error = err } end
+    local ok, result = pcall(fileExists, f)
+    if not ok then return { success = false, error = tostring(result) } end
+    return { success = true, exists = result == true }
+end
+
+local function cmd_delete_file(params)
+    local filename = params.filename
+    local f, err = sanitizeFilename(filename)
+    if not f then return { success = false, error = err } end
+    local ok, result = pcall(deleteFile, f)
+    if not ok then return { success = false, error = tostring(result) } end
+    return { success = true }
+end
+
+local function listPathEntries(path, ceFn, resultKey)
+    local f, err = sanitizeFilename(path)
+    if not f then return { success = false, error = err } end
+    local ok, result = pcall(ceFn, f)
+    if not ok then return { success = false, error = tostring(result) } end
+    local entries = {}
+    if type(result) == "table" then
+        for _, v in ipairs(result) do table.insert(entries, v) end
+    end
+    return { success = true, count = #entries, [resultKey] = entries }
+end
+
+local function cmd_get_file_list(params)
+    return listPathEntries(params.path, getFileList, "files")
+end
+
+local function cmd_get_directory_list(params)
+    return listPathEntries(params.path, getDirectoryList, "directories")
+end
+
+local function cmd_get_temp_folder(params)
+    local ok, result = pcall(getTempFolder)
+    if not ok then return { success = false, error = tostring(result) } end
+    return { success = true, path = tostring(result) }
+end
+
+local function cmd_get_file_version(params)
+    local f, err = sanitizeFilename(params.filename)
+    if not f then return { success = false, error = err } end
+    -- getFileVersion returns two values; wrap in a closure so pcall captures both
+    local ok, errOrRaw, verTable = pcall(function() return getFileVersion(f) end)
+    if not ok then return { success = false, error = tostring(errOrRaw) } end
+    if type(verTable) ~= "table" then
+        return { success = false, error = "getFileVersion did not return a version table" }
+    end
+    local major   = verTable.major   or 0
+    local minor   = verTable.minor   or 0
+    local release = verTable.release or 0
+    local build   = verTable.build   or 0
+    return {
+        success = true,
+        major = major,
+        minor = minor,
+        release = release,
+        build = build,
+        version_string = string.format("%d.%d.%d.%d", major, minor, release, build)
+    }
+end
+
+local function cmd_read_clipboard(params)
+    local ok, result = pcall(readFromClipboard)
+    if not ok then return { success = false, error = tostring(result) } end
+    return { success = true, text = tostring(result or "") }
+end
+
+local function cmd_write_clipboard(params)
+    local text = params.text
+    if type(text) ~= "string" then return { success = false, error = "text must be a string" } end
+    local ok, err = pcall(writeToClipboard, text)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+-- >>> END UNIT-20a <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2225,14 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+    file_exists = cmd_file_exists,
+    delete_file = cmd_delete_file,
+    get_file_list = cmd_get_file_list,
+    get_directory_list = cmd_get_directory_list,
+    get_temp_folder = cmd_get_temp_folder,
+    get_file_version = cmd_get_file_version,
+    read_clipboard = cmd_read_clipboard,
+    write_clipboard = cmd_write_clipboard,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,55 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# >>> BEGIN UNIT-20a File IO Clipboard <<<
+
+@mcp.tool()
+def file_exists(filename: str) -> str:
+    """Check whether a file exists at the given path. Returns {success, exists: bool}."""
+    return format_result(ce_client.send_command("file_exists", {"filename": filename}))
+
+@mcp.tool()
+def delete_file(filename: str) -> str:
+    """Delete a file at the given path. Returns {success}.
+
+    WARNING: This is a destructive operation. The file will be permanently deleted
+    from disk. Path traversal sequences ('..') are blocked by the bridge. Use with
+    extreme caution — there is no undo.
+    """
+    return format_result(ce_client.send_command("delete_file", {"filename": filename}))
+
+@mcp.tool()
+def get_file_list(path: str) -> str:
+    """List files in the given directory path. Returns {success, count, files: [str]}."""
+    return format_result(ce_client.send_command("get_file_list", {"path": path}))
+
+@mcp.tool()
+def get_directory_list(path: str) -> str:
+    """List subdirectories in the given directory path. Returns {success, count, directories: [str]}."""
+    return format_result(ce_client.send_command("get_directory_list", {"path": path}))
+
+@mcp.tool()
+def get_temp_folder() -> str:
+    """Return the path to the system temp folder. Returns {success, path: str}."""
+    return format_result(ce_client.send_command("get_temp_folder"))
+
+@mcp.tool()
+def get_file_version(filename: str) -> str:
+    """Get the version info of a file (major, minor, release, build). Returns {success, major, minor, release, build, version_string}."""
+    return format_result(ce_client.send_command("get_file_version", {"filename": filename}))
+
+@mcp.tool()
+def read_clipboard() -> str:
+    """Read text from the system clipboard. Returns {success, text: str}."""
+    return format_result(ce_client.send_command("read_clipboard"))
+
+@mcp.tool()
+def write_clipboard(text: str) -> str:
+    """Write text to the system clipboard. Returns {success}."""
+    return format_result(ce_client.send_command("write_clipboard", {"text": text}))
+
+# >>> END UNIT-20a <<<
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
8 new MCP tools for file I/O and clipboard:
- `file_exists` / `delete_file` — basic file ops (delete flagged as destructive).
- `get_file_list` / `get_directory_list` — directory enumeration (shared `listPathEntries` helper).
- `get_temp_folder` — CE temp folder path.
- `get_file_version` — Windows version info.
- `read_clipboard` / `write_clipboard` — clipboard R/W.

All filename params are sanitized against path traversal.

## Unit
Unit 20a of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)