### PR TITLE
feat(unit-20b): gated shell execution tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2055,6 +2055,57 @@ local function cmd_stop_dbvm_watch(params)
 end
 
 -- ============================================================================
+-- UNIT-20b: Shell Execution Handlers
+-- NOTE: Security gate (CE_MCP_ALLOW_SHELL env var check) is enforced on the
+--       Python side, before this Lua code is ever reached.
+-- ============================================================================
+
+-- run_command: Wraps CE's runCommand(exepath, parameters, pathtoexecutein)
+-- Returns output string and exit code. SECURITY: arbitrary code execution.
+local function cmd_run_command(params)
+    local command = params.command
+    local args = params.args or ""
+
+    if not command or command == "" then
+        return { success = false, error = "No command provided" }
+    end
+
+    local ok, output, exitCode = pcall(runCommand, command, args)
+
+    if not ok then
+        return { success = false, error = "runCommand failed: " .. tostring(output) }
+    end
+
+    return {
+        success = true,
+        output = tostring(output or ""),
+        exit_code = tonumber(exitCode) or 0
+    }
+end
+
+-- shell_execute: Wraps CE's shellExecute(command, parameters, folder, showcommand)
+-- SECURITY: arbitrary code execution via Windows ShellExecute.
+local function cmd_shell_execute(params)
+    local command = params.command
+    local args = params.args or ""
+    local workingDir = params.working_dir or ""
+
+    if not command or command == "" then
+        return { success = false, error = "No command provided" }
+    end
+
+    local ok, err = pcall(shellExecute, command, args, workingDir ~= "" and workingDir or nil)
+
+    if not ok then
+        return { success = false, error = "shellExecute failed: " .. tostring(err) }
+    end
+
+    return { success = true }
+end
+
+-- >>> END UNIT-20b <<<
+
+-- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
 
@@ -2131,6 +2182,10 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Shell Execution (UNIT-20b) - Security gate enforced on Python side
+    run_command = cmd_run_command,
+    shell_execute = cmd_shell_execute,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,56 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# >>> BEGIN UNIT-20b Shell Execution <<<
+def _check_shell_gate():
+    if os.environ.get("CE_MCP_ALLOW_SHELL") != "1":
+        return json.dumps({
+            "success": False,
+            "error": "Shell execution disabled. Set environment variable CE_MCP_ALLOW_SHELL=1 to enable.",
+            "error_code": "PERMISSION_DENIED"
+        })
+    return None
+
+@mcp.tool()
+def run_command(command: str, args: str = "") -> str:
+    """Execute a shell command in the host OS. SECURITY: Arbitrary code execution.
+
+    REQUIRES environment variable CE_MCP_ALLOW_SHELL=1 at server startup.
+    By default, this tool returns a PERMISSION_DENIED error.
+
+    Args:
+        command: Command path or name (e.g. "notepad.exe", "cmd.exe").
+        args: Arguments string.
+
+    Returns JSON with: success, output, exit_code.
+    """
+    blocked = _check_shell_gate()
+    if blocked:
+        return blocked
+    return format_result(ce_client.send_command("run_command", {"command": command, "args": args}))
+
+@mcp.tool()
+def shell_execute(command: str, args: str = "", verb: str = "open", working_dir: str = "") -> str:
+    """Invoke Windows ShellExecute. SECURITY: Arbitrary code execution.
+
+    REQUIRES environment variable CE_MCP_ALLOW_SHELL=1 at server startup.
+
+    Args:
+        command: Command or file to execute.
+        args: Arguments string.
+        verb: ShellExecute verb ("open", "edit", "print", "runas", etc.).
+        working_dir: Working directory (empty for current).
+
+    Returns JSON with: success.
+    """
+    blocked = _check_shell_gate()
+    if blocked:
+        return blocked
+    return format_result(ce_client.send_command("shell_execute", {
+        "command": command, "args": args, "verb": verb, "working_dir": working_dir
+    }))
+# >>> END UNIT-20b <<<
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
2 new MCP tools wrapping CE's host-shell-execution APIs, **gated behind the `CE_MCP_ALLOW_SHELL=1` env var** at the Python layer (before the JSON-RPC call is even made):
- `run_command` — host command execution with stdout capture.
- `shell_execute` — Windows ShellExecute wrapper.

By default both return `PERMISSION_DENIED`. Docstrings carry prominent arbitrary-code-execution warnings.

## Unit
Unit 20b of 26.

## Testing
Static checks only.

## Security
⚠️ These tools enable arbitrary code execution on the host OS. Only enable in trusted environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)