### PR TITLE
feat(unit-21): kernel mode and DBVM extension tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -173,7 +173,16 @@ local function cleanupZombieState()
     serverState.breakpoint_hits = {}
     serverState.hw_bp_slots = {}
     serverState.active_watches = {}
-    
+
+    -- 4. Release any mapped memory MDL handles (Unit-21)
+    if mappedMemoryMDL then
+        for key, mdl in pairs(mappedMemoryMDL) do
+            pcall(function() unmapMemory(getAddressSafe(key) or 0, mdl) end)
+        end
+        -- mappedMemoryMDL is module-level, reassign to clear it
+        for k in pairs(mappedMemoryMDL) do mappedMemoryMDL[k] = nil end
+    end
+
     if cleaned.breakpoints > 0 or cleaned.dbvm_watches > 0 or cleaned.scans > 0 then
         log(string.format("Cleaned: %d breakpoints, %d DBVM watches, %d scans", 
             cleaned.breakpoints, cleaned.dbvm_watches, cleaned.scans))
@@ -2054,6 +2063,195 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-21 Kernel DBVM <<<
+-- ============================================================================
+-- COMMAND HANDLERS - KERNEL MODE / DBVM EXTENSIONS (Unit 21)
+-- Requires DBK kernel driver and/or DBVM hypervisor to be loaded.
+-- ============================================================================
+
+-- MDL handles for active mapMemory() calls, keyed by mapped-address hex string.
+-- mapMemory() returns (address, mdl); unmapMemory() needs the mdl to release it.
+-- Cleared by cleanupZombieState() on bridge stop/restart.
+local mappedMemoryMDL = {}
+
+local function dbkNotLoadedError()
+    return {
+        success = false,
+        error = "Kernel driver (DBK) or hypervisor (DBVM) not loaded",
+        error_code = "DBK_NOT_LOADED"
+    }
+end
+
+local function cmd_dbk_get_cr0(params)
+    local ok, result = pcall(dbk_getCR0)
+    if not ok then return dbkNotLoadedError() end
+    return { success = true, cr0 = toHex(result) }
+end
+
+local function cmd_dbk_get_cr3(params)
+    local ok, result = pcall(dbk_getCR3)
+    if not ok then return dbkNotLoadedError() end
+    return { success = true, cr3 = toHex(result) }
+end
+
+local function cmd_dbk_get_cr4(params)
+    local ok, result = pcall(dbk_getCR4)
+    if not ok then return dbkNotLoadedError() end
+    return { success = true, cr4 = toHex(result) }
+end
+
+local function cmd_read_process_memory_cr3(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return { success = false, error = "No process attached" }
+    end
+
+    local cr3_str  = params.cr3
+    local addr_str = params.address
+    local size     = tonumber(params.size)
+
+    if not cr3_str or not addr_str or not size or size <= 0 then
+        return { success = false, error = "Parameters cr3, address and size are required" }
+    end
+
+    local cr3  = type(cr3_str)  == "string" and getAddressSafe(cr3_str)  or cr3_str
+    local addr = type(addr_str) == "string" and getAddressSafe(addr_str) or addr_str
+    if not cr3 or not addr then
+        return { success = false, error = "Invalid cr3 or address value" }
+    end
+
+    local ok, byteTable = pcall(readProcessMemoryCR3, cr3, addr, size)
+    if not ok then return dbkNotLoadedError() end
+    if not byteTable then
+        return { success = false, error = "Read failed — page may be paged out or invalid" }
+    end
+
+    return { success = true, bytes = byteTable, size = #byteTable }
+end
+
+local function cmd_write_process_memory_cr3(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return { success = false, error = "No process attached" }
+    end
+
+    local cr3_str  = params.cr3
+    local addr_str = params.address
+    local bytes    = params.bytes
+
+    if not cr3_str or not addr_str or not bytes or type(bytes) ~= "table" then
+        return { success = false, error = "Parameters cr3, address and bytes (list) are required" }
+    end
+
+    local cr3  = type(cr3_str)  == "string" and getAddressSafe(cr3_str)  or cr3_str
+    local addr = type(addr_str) == "string" and getAddressSafe(addr_str) or addr_str
+    if not cr3 or not addr then
+        return { success = false, error = "Invalid cr3 or address value" }
+    end
+
+    local ok = pcall(writeProcessMemoryCR3, cr3, addr, bytes)
+    if not ok then return dbkNotLoadedError() end
+
+    return { success = true, bytes_written = #bytes }
+end
+
+local function cmd_map_memory(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return { success = false, error = "No process attached" }
+    end
+
+    local addr_str = params.address
+    local size     = tonumber(params.size)
+
+    if not addr_str or not size or size <= 0 then
+        return { success = false, error = "Parameters address and size are required" }
+    end
+
+    local addr = type(addr_str) == "string" and getAddressSafe(addr_str) or addr_str
+    if not addr then
+        return { success = false, error = "Invalid address value" }
+    end
+
+    local ok, mappedAddr, mdl = pcall(mapMemory, addr, size)
+    if not ok then return dbkNotLoadedError() end
+    if not mappedAddr then
+        return { success = false, error = "mapMemory failed — address may be invalid or DBK not loaded" }
+    end
+
+    local key = toHex(mappedAddr)
+    mappedMemoryMDL[key] = mdl  -- retain MDL so unmap_memory can release it
+
+    return { success = true, mapped_address = key }
+end
+
+local function cmd_unmap_memory(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return { success = false, error = "No process attached" }
+    end
+
+    local addr_str = params.mapped_address
+    if not addr_str then
+        return { success = false, error = "Parameter mapped_address is required" }
+    end
+
+    local addr = type(addr_str) == "string" and getAddressSafe(addr_str) or addr_str
+    if not addr then
+        return { success = false, error = "Invalid mapped_address value" }
+    end
+
+    local key = toHex(addr)
+    local ok  = pcall(unmapMemory, addr, mappedMemoryMDL[key])
+    if not ok then return dbkNotLoadedError() end
+
+    mappedMemoryMDL[key] = nil
+
+    return { success = true }
+end
+
+local function cmd_dbk_writes_ignore_write_protection(params)
+    local enable = params.enable
+    if type(enable) ~= "boolean" then
+        return { success = false, error = "Parameter enable (boolean) is required" }
+    end
+
+    local ok = pcall(dbk_writesIgnoreWriteProtection, enable)
+    if not ok then return dbkNotLoadedError() end
+
+    return { success = true }
+end
+
+local function cmd_get_physical_address_cr3(params)
+    local pid = getOpenedProcessID()
+    if not pid or pid == 0 then
+        return { success = false, error = "No process attached" }
+    end
+
+    local cr3_str = params.cr3
+    local va_str  = params.virtual_address
+
+    if not cr3_str or not va_str then
+        return { success = false, error = "Parameters cr3 and virtual_address are required" }
+    end
+
+    local cr3 = type(cr3_str) == "string" and getAddressSafe(cr3_str) or cr3_str
+    local va  = type(va_str)  == "string" and getAddressSafe(va_str)  or va_str
+    if not cr3 or not va then
+        return { success = false, error = "Invalid cr3 or virtual_address value" }
+    end
+
+    local ok, phys = pcall(getPhysicalAddressCR3, cr3, va)
+    if not ok then return dbkNotLoadedError() end
+    if not phys then
+        return { success = false, error = "Address not paged — virtual address may not be mapped in this CR3" }
+    end
+
+    return { success = true, physical_address = toHex(phys) }
+end
+
+-- >>> END UNIT-21 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2129,6 +2327,17 @@ local commandHandlers = {
     find_what_accesses_safe = cmd_start_dbvm_watch,  -- Alias: start watching for accesses
     get_watch_results = cmd_stop_dbvm_watch,  -- Alias: retrieve results and stop
     
+    -- Unit-21: Kernel Mode / DBVM Extensions
+    dbk_get_cr0 = cmd_dbk_get_cr0,
+    dbk_get_cr3 = cmd_dbk_get_cr3,
+    dbk_get_cr4 = cmd_dbk_get_cr4,
+    read_process_memory_cr3 = cmd_read_process_memory_cr3,
+    write_process_memory_cr3 = cmd_write_process_memory_cr3,
+    map_memory = cmd_map_memory,
+    unmap_memory = cmd_unmap_memory,
+    dbk_writes_ignore_write_protection = cmd_dbk_writes_ignore_write_protection,
+    get_physical_address_cr3 = cmd_get_physical_address_cr3,
+
     -- Utility
     ping = cmd_ping,
 }

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -472,6 +472,145 @@ def poll_dbvm_watch(address: str, max_results: int = 1000) -> str:
         "max_results": max_results
     }))
 
+# --- KERNEL MODE / DBVM EXTENSIONS (Unit 21) ---
+
+@mcp.tool()
+def dbk_get_cr0() -> str:
+    """Read Control Register 0 (CR0) via the DBK kernel driver.
+
+    Requires the DBK kernel driver to be loaded (CE Settings -> Debugger -> Kernelmode).
+    Returns cr0 as a hex string.
+    """
+    return format_result(ce_client.send_command("dbk_get_cr0"))
+
+@mcp.tool()
+def dbk_get_cr3() -> str:
+    """Read Control Register 3 (CR3 — page-table base) via DBK or DBVM.
+
+    Works when either the DBK kernel driver or the DBVM hypervisor is loaded.
+    Returns cr3 as a hex string.
+    """
+    return format_result(ce_client.send_command("dbk_get_cr3"))
+
+@mcp.tool()
+def dbk_get_cr4() -> str:
+    """Read Control Register 4 (CR4) via the DBK kernel driver.
+
+    Requires the DBK kernel driver to be loaded (CE Settings -> Debugger -> Kernelmode).
+    Returns cr4 as a hex string.
+    """
+    return format_result(ce_client.send_command("dbk_get_cr4"))
+
+@mcp.tool()
+def read_process_memory_cr3(cr3: str, address: str, size: int) -> str:
+    """Read virtual memory using an explicit CR3 page-table base via DBK/DBVM.
+
+    Bypasses the standard OS memory-translation path, making it effective for
+    processes that hide memory from normal reads (e.g. anti-cheat analysis).
+
+    Requires: DBK kernel driver or DBVM hypervisor loaded; a process must be attached.
+
+    Args:
+        cr3: CR3 value (hex string or integer) identifying the target page table.
+        address: Virtual address to read from (hex string or symbol name).
+        size: Number of bytes to read.
+    """
+    return format_result(ce_client.send_command(
+        "read_process_memory_cr3",
+        {"cr3": cr3, "address": address, "size": size}
+    ))
+
+@mcp.tool()
+def write_process_memory_cr3(cr3: str, address: str, bytes: list) -> str:
+    """Write to virtual memory using an explicit CR3 page-table base via DBK/DBVM.
+
+    Bypasses the standard OS memory-translation path.
+
+    Requires: DBK kernel driver or DBVM hypervisor loaded; a process must be attached.
+
+    Args:
+        cr3: CR3 value (hex string or integer) identifying the target page table.
+        address: Virtual address to write to (hex string or symbol name).
+        bytes: List of integer byte values to write.
+    """
+    return format_result(ce_client.send_command(
+        "write_process_memory_cr3",
+        {"cr3": cr3, "address": address, "bytes": bytes}
+    ))
+
+@mcp.tool()
+def map_memory(address: str, size: int) -> str:
+    """Map a kernel/physical address range into the CE usermode context via DBK.
+
+    Returns a mapped_address that can be used for ordinary memory reads/writes.
+    Call unmap_memory() with the same mapped_address when finished.
+
+    Requires: DBK kernel driver loaded; a process must be attached.
+
+    Args:
+        address: Source address to map (hex string or symbol name).
+        size: Number of bytes to map.
+    """
+    return format_result(ce_client.send_command(
+        "map_memory",
+        {"address": address, "size": size}
+    ))
+
+@mcp.tool()
+def unmap_memory(mapped_address: str, size: int = 0) -> str:
+    """Release a memory mapping created by map_memory().
+
+    The size parameter is accepted for API compatibility but unused internally;
+    the MDL handle captured during map_memory() is used to release the mapping.
+
+    Requires: DBK kernel driver loaded; a process must be attached.
+
+    Args:
+        mapped_address: The mapped address returned by a prior map_memory() call.
+        size: Unused; kept for API symmetry with map_memory().
+    """
+    return format_result(ce_client.send_command(
+        "unmap_memory",
+        {"mapped_address": mapped_address, "size": size}
+    ))
+
+@mcp.tool()
+def dbk_writes_ignore_write_protection(enable: bool) -> str:
+    """Toggle whether DBK memory writes bypass copy-on-write (CoW) protection.
+
+    When enabled, writes go directly to the underlying physical page instead of
+    triggering a page fault and creating a process-private copy. Useful when
+    patching shared read-only pages across all processes simultaneously.
+
+    Requires: DBK kernel driver loaded.
+
+    Args:
+        enable: True to bypass CoW; False to restore normal CoW behaviour.
+    """
+    return format_result(ce_client.send_command(
+        "dbk_writes_ignore_write_protection",
+        {"enable": enable}
+    ))
+
+@mcp.tool()
+def get_physical_address_cr3(cr3: str, virtual_address: str) -> str:
+    """Translate a virtual address to its physical address using an explicit CR3.
+
+    Unlike get_physical_address (which uses the currently attached process's CR3),
+    this function lets you walk any process's page table — useful for cross-process
+    physical memory analysis.
+
+    Requires: DBK kernel driver or DBVM hypervisor loaded; a process must be attached.
+
+    Args:
+        cr3: CR3 value (hex string or integer) of the target process's page table.
+        virtual_address: Virtual address to translate (hex string or symbol name).
+    """
+    return format_result(ce_client.send_command(
+        "get_physical_address_cr3",
+        {"cr3": cr3, "virtual_address": virtual_address}
+    ))
+
 # --- SCRIPTING & CONTROL ---
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
9 new MCP tools for kernel-mode and DBVM operations:
- `dbk_get_cr0` / `dbk_get_cr3` / `dbk_get_cr4` — control register reads.
- `read_process_memory_cr3` / `write_process_memory_cr3` — CR3-based memory access (bypasses normal VM translation).
- `map_memory` / `unmap_memory` — kernel memory mapping with MDL registry.
- `dbk_writes_ignore_write_protection` — copy-on-write bypass toggle.
- `get_physical_address_cr3` — VA→PA translation under a specific CR3.

All return `DBK_NOT_LOADED` when the kernel driver is absent. The `mapMemory` MDL registry is cleaned up in `cleanupZombieState` to prevent leaks on script reload.

## Unit
Unit 21 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)