### PR TITLE
feat(unit-22): CE threading and synchronization primitives

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -1316,6 +1316,99 @@ local function cmd_evaluate_lua(params)
     return { success = true, result = tostring(result) }
 end
 
+-- >>> BEGIN UNIT-22 Threading Sync <<<
+-- ============================================================================
+-- COMMAND HANDLERS - THREADING & SYNCHRONIZATION
+-- These operate on CE's Lua scripting host, NOT the target process.
+-- No process guard is needed or appropriate here.
+-- ============================================================================
+
+local _unit22_thread_counter = 0
+
+local function cmd_create_thread(params)
+    -- SECURITY WARNING: This tool executes arbitrary Lua code inside CE's process.
+    -- It carries the same risk as evaluate_lua. Only use with trusted code.
+    local code = params.code
+    local arg  = params.arg or ""
+    if not code then return { success = false, error = "No code provided" } end
+
+    local ok, err = pcall(function()
+        createThread(function(thread, a)
+            local f, ferr = loadstring(code)
+            if not f then error("Compile error: " .. tostring(ferr)) end
+            return f(thread, a)
+        end, arg)
+    end)
+
+    if not ok then
+        return { success = false, error = "createThread failed: " .. tostring(err) }
+    end
+    _unit22_thread_counter = _unit22_thread_counter + 1
+    return { success = true, thread_id = _unit22_thread_counter }
+end
+
+local function cmd_get_global_variable(params)
+    local name = params.name
+    if not name then return { success = false, error = "No variable name provided" } end
+
+    local ok, value = pcall(getGlobalVariable, name)
+    if not ok then
+        return { success = false, error = "getGlobalVariable failed: " .. tostring(value) }
+    end
+    return { success = true, value = tostring(value) }
+end
+
+local function cmd_set_global_variable(params)
+    local name  = params.name
+    local value = params.value
+    if not name  then return { success = false, error = "No variable name provided"  } end
+    if value == nil then return { success = false, error = "No value provided" } end
+
+    local ok, err = pcall(setGlobalVariable, name, value)
+    if not ok then
+        return { success = false, error = "setGlobalVariable failed: " .. tostring(err) }
+    end
+    return { success = true }
+end
+
+local function cmd_queue_to_main_thread(params)
+    -- SECURITY WARNING: This tool executes arbitrary Lua code inside CE's process
+    -- on the main thread. It carries the same risk as evaluate_lua.
+    local code = params.code
+    if not code then return { success = false, error = "No code provided" } end
+
+    local ok, err = pcall(function()
+        queue(function()
+            local f, ferr = loadstring(code)
+            if not f then error("Compile error: " .. tostring(ferr)) end
+            f()
+        end)
+    end)
+
+    if not ok then
+        return { success = false, error = "queue failed: " .. tostring(err) }
+    end
+    return { success = true }
+end
+
+local function cmd_check_synchronize(params)
+    local ok, err = pcall(checkSynchronize)
+    if not ok then
+        return { success = false, error = "checkSynchronize failed: " .. tostring(err) }
+    end
+    return { success = true }
+end
+
+local function cmd_in_main_thread(params)
+    local ok, result = pcall(inMainThread)
+    if not ok then
+        return { success = false, error = "inMainThread failed: " .. tostring(result) }
+    end
+    return { success = true, is_main_thread = result == true }
+end
+
+-- >>> END UNIT-22 <<<
+
 -- ============================================================================
 -- COMMAND HANDLERS - MEMORY REGIONS
 -- ============================================================================
@@ -2108,6 +2201,14 @@ local commandHandlers = {
     
     -- Lua Evaluation
     evaluate_lua = cmd_evaluate_lua,
+
+    -- Threading & Synchronization (Unit-22)
+    create_thread           = cmd_create_thread,
+    get_global_variable     = cmd_get_global_variable,
+    set_global_variable     = cmd_set_global_variable,
+    queue_to_main_thread    = cmd_queue_to_main_thread,
+    check_synchronize       = cmd_check_synchronize,
+    in_main_thread          = cmd_in_main_thread,
     
     -- High-Level Analysis Tools
     dissect_structure = cmd_dissect_structure,

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,66 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- THREADING & SYNCHRONIZATION (Unit-22) ---
+
+@mcp.tool()
+def create_thread(code: str, arg: str = "") -> str:
+    """Execute Lua code in a new CE thread.
+
+    SECURITY WARNING: This tool executes arbitrary Lua code inside CE's process,
+    carrying the same risk as evaluate_lua. Only use with trusted code.
+
+    Returns {success, thread_id}.
+    """
+    return format_result(ce_client.send_command("create_thread", {"code": code, "arg": arg}))
+
+@mcp.tool()
+def get_global_variable(name: str) -> str:
+    """Read a global variable from CE's main Lua state.
+
+    Useful for reading values set by scripts running in other threads.
+    Returns {success, value} where value is stringified via tostring().
+    """
+    return format_result(ce_client.send_command("get_global_variable", {"name": name}))
+
+@mcp.tool()
+def set_global_variable(name: str, value: str) -> str:
+    """Write a global variable in CE's main Lua state.
+
+    Useful for passing values to scripts running in other threads.
+    Returns {success}.
+    """
+    return format_result(ce_client.send_command("set_global_variable", {"name": name, "value": value}))
+
+@mcp.tool()
+def queue_to_main_thread(code: str) -> str:
+    """Queue Lua code to run on CE's main thread without waiting for its result.
+
+    SECURITY WARNING: This tool executes arbitrary Lua code inside CE's process
+    on the main thread, carrying the same risk as evaluate_lua. Only use with
+    trusted code.
+
+    Returns {success}.
+    """
+    return format_result(ce_client.send_command("queue_to_main_thread", {"code": code}))
+
+@mcp.tool()
+def check_synchronize() -> str:
+    """Process queued main-thread calls (checkSynchronize).
+
+    Call this from an infinite loop in the main thread when using threading
+    and synchronize calls. Returns {success}.
+    """
+    return format_result(ce_client.send_command("check_synchronize"))
+
+@mcp.tool()
+def in_main_thread() -> str:
+    """Check whether the current code is running in CE's main thread.
+
+    Returns {success, is_main_thread}.
+    """
+    return format_result(ce_client.send_command("in_main_thread"))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
6 new MCP tools operating on CE's Lua scripting environment (not the target process):
- `create_thread` — spawn a new CE Lua thread.
- `get_global_variable` / `set_global_variable` — cross-thread data passing.
- `queue_to_main_thread` — queue a call for main-thread execution.
- `check_synchronize` — process queued calls.
- `in_main_thread` — main thread query.

`create_thread` and `queue_to_main_thread` execute arbitrary Lua code; security warnings in docstrings.

## Unit
Unit 22 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)