### PR TITLE
feat(unit-23): debug output, text-to-speech, sound, and progress tools

### DIFF
--- a/MCP_Server/ce_mcp_bridge.lua
+++ b/MCP_Server/ce_mcp_bridge.lua
@@ -2054,6 +2054,79 @@ local function cmd_stop_dbvm_watch(params)
     }
 end
 
+-- >>> BEGIN UNIT-23 Debug Multimedia <<<
+
+local progressStateMap = {
+    none          = tbpsNone,
+    normal        = tbpsNormal,
+    paused        = tbpsPaused,
+    error         = tbpsError,
+    indeterminate = tbpsIndeterminate,
+}
+
+local function cmd_output_debug_string(params)
+    local message = params.message
+    if type(message) ~= "string" then
+        return { success = false, error = "message must be a string", error_code = "INVALID_PARAMS" }
+    end
+    local ok, err = pcall(outputDebugString, message)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_speak_text(params)
+    local text = params.text
+    if type(text) ~= "string" then
+        return { success = false, error = "text must be a string", error_code = "INVALID_PARAMS" }
+    end
+    local ok, err
+    if params.english_only then
+        ok, err = pcall(speakEnglish, text)
+    else
+        ok, err = pcall(speak, text)
+    end
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_play_sound(params)
+    if type(params.filename) ~= "string" or params.filename:find("%.%.") then
+        return { success = false, error = "Invalid filename", error_code = "INVALID_PARAMS" }
+    end
+    local ok, err = pcall(playSound, params.filename)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_beep(params)
+    local ok, err = pcall(beep)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_set_progress_state(params)
+    local tbState = progressStateMap[params.state]
+    if not tbState then
+        return { success = false, error = "state must be one of: none, normal, paused, error, indeterminate", error_code = "INVALID_PARAMS" }
+    end
+    local ok, err = pcall(setProgressState, tbState)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+local function cmd_set_progress_value(params)
+    local current = params.current
+    local max = params.max
+    if type(current) ~= "number" or type(max) ~= "number" then
+        return { success = false, error = "current and max must be numbers", error_code = "INVALID_PARAMS" }
+    end
+    local ok, err = pcall(setProgressValue, current, max)
+    if not ok then return { success = false, error = tostring(err) } end
+    return { success = true }
+end
+
+-- >>> END UNIT-23 <<<
+
 -- ============================================================================
 -- COMMAND DISPATCHER
 -- ============================================================================
@@ -2131,6 +2204,14 @@ local commandHandlers = {
     
     -- Utility
     ping = cmd_ping,
+
+    -- Debug Output & Multimedia (Unit 23)
+    output_debug_string = cmd_output_debug_string,
+    speak_text = cmd_speak_text,
+    play_sound = cmd_play_sound,
+    beep = cmd_beep,
+    set_progress_state = cmd_set_progress_state,
+    set_progress_value = cmd_set_progress_value,
 }
 
 -- ============================================================================

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -489,6 +489,38 @@ def ping() -> str:
     """Check connectivity and get version info."""
     return format_result(ce_client.send_command("ping"))
 
+# --- DEBUG OUTPUT & MULTIMEDIA (Unit 23) ---
+
+@mcp.tool()
+def output_debug_string(message: str) -> str:
+    """Post a message to the Windows debugger via OutputDebugString (readable with tools like DebugView)."""
+    return format_result(ce_client.send_command("output_debug_string", {"message": message}))
+
+@mcp.tool()
+def speak_text(text: str, english_only: bool = False) -> str:
+    """Speak text via Windows SAPI text-to-speech. Set english_only=True to force the English voice."""
+    return format_result(ce_client.send_command("speak_text", {"text": text, "english_only": english_only}))
+
+@mcp.tool()
+def play_sound(filename: str) -> str:
+    """Play a WAV sound file by filename. Path must not contain '..' directory traversal."""
+    return format_result(ce_client.send_command("play_sound", {"filename": filename}))
+
+@mcp.tool()
+def beep() -> str:
+    """Play a simple system beep sound."""
+    return format_result(ce_client.send_command("beep", {}))
+
+@mcp.tool()
+def set_progress_state(state: str) -> str:
+    """Set the Cheat Engine taskbar progress state. Valid states: none, normal, paused, error, indeterminate."""
+    return format_result(ce_client.send_command("set_progress_state", {"state": state}))
+
+@mcp.tool()
+def set_progress_value(current: int, max: int) -> str:
+    """Set the Cheat Engine taskbar progress bar position. Provide current value and maximum value."""
+    return format_result(ce_client.send_command("set_progress_value", {"current": current, "max": max}))
+
 if __name__ == "__main__":
     try:
         debug_log("Starting FastMCP server (v11/v99 compatible)...")


### PR DESCRIPTION
## Summary
6 new MCP tools for debug output and multimedia:
- `output_debug_string` — Windows `OutputDebugStringA`.
- `speak_text` — SAPI text-to-speech (`english_only` flag).
- `play_sound` — plays a sound file (path-traversal guarded).
- `beep` — system beep.
- `set_progress_state` / `set_progress_value` — Windows taskbar progress indicator on the CE window.

## Unit
Unit 23 of 26.

## Testing
Static checks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)