### PR TITLE
feat: add TCP relay transport for Cheat Engine MCP bridge

### DIFF
--- a/MCP_Server/ce_tcp_relay.py
+++ b/MCP_Server/ce_tcp_relay.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+r"""TCP-to-named-pipe relay for the Cheat Engine MCP bridge.
+
+Run this script on Windows while ``ce_mcp_bridge.lua`` is loaded in Cheat
+Engine. It accepts the same length-prefixed JSON-RPC frames used by
+``mcp_cheatengine.py`` and forwards them to ``\\.\pipe\CE_MCP_Bridge_v99``.
+
+Use this when the MCP server cannot open the Windows named pipe directly, such
+as from WSL, a container, or another host.
+
+Bind to 127.0.0.1 unless you intentionally want to expose Cheat Engine control
+to another machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import socketserver
+import struct
+import sys
+from typing import Optional
+
+try:
+    import pywintypes
+    import win32file
+except ImportError as exc:  # pragma: no cover - Windows-only helper
+    print("ce_tcp_relay.py must run on Windows with pywin32 installed.", file=sys.stderr)
+    raise SystemExit(1) from exc
+
+
+PIPE_NAME = r"\\.\pipe\CE_MCP_Bridge_v99"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 9876
+MAX_FRAME_SIZE_BYTES = 32 * 1024 * 1024
+
+
+def read_socket_exact(sock: socket.socket, size: int) -> Optional[bytes]:
+    """Read exactly size bytes, returning None on clean peer disconnect."""
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining > 0:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            if remaining == size:
+                return None
+            raise ConnectionError("TCP client disconnected mid-frame.")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def read_pipe_exact(handle, size: int) -> bytes:
+    """Read exactly size bytes from a Windows named pipe."""
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining > 0:
+        chunk = win32file.ReadFile(handle, remaining)[1]
+        if not chunk:
+            raise ConnectionError("Cheat Engine pipe closed mid-frame.")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def validate_frame_size(size: int, direction: str) -> None:
+    if size > MAX_FRAME_SIZE_BYTES:
+        raise ConnectionError(
+            f"{direction} frame too large: {size} bytes "
+            f"(max {MAX_FRAME_SIZE_BYTES} bytes)."
+        )
+
+
+def open_pipe():
+    return win32file.CreateFile(
+        PIPE_NAME,
+        win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+        0,
+        None,
+        win32file.OPEN_EXISTING,
+        0,
+        None,
+    )
+
+
+class RelayHandler(socketserver.BaseRequestHandler):
+    """Relay one TCP client connection to one persistent CE pipe connection."""
+
+    pipe_handle = None
+
+    def setup(self) -> None:
+        self.pipe_handle = None
+        self.request.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+    def handle(self) -> None:
+        peer = f"{self.client_address[0]}:{self.client_address[1]}"
+        print(f"[relay] TCP client connected: {peer}", file=sys.stderr, flush=True)
+        try:
+            self.pipe_handle = open_pipe()
+            while True:
+                req_header = read_socket_exact(self.request, 4)
+                if req_header is None:
+                    break
+                req_len = struct.unpack("<I", req_header)[0]
+                validate_frame_size(req_len, "request")
+                req_body = read_socket_exact(self.request, req_len)
+                if req_body is None:
+                    raise ConnectionError("TCP client disconnected before request body.")
+
+                win32file.WriteFile(self.pipe_handle, req_header)
+                win32file.WriteFile(self.pipe_handle, req_body)
+
+                resp_header = read_pipe_exact(self.pipe_handle, 4)
+                resp_len = struct.unpack("<I", resp_header)[0]
+                validate_frame_size(resp_len, "response")
+                resp_body = read_pipe_exact(self.pipe_handle, resp_len)
+                self.request.sendall(resp_header + resp_body)
+        except pywintypes.error as exc:
+            print(f"[relay] Windows pipe error for {peer}: {exc}", file=sys.stderr, flush=True)
+        except (ConnectionError, OSError) as exc:
+            print(f"[relay] Connection ended for {peer}: {exc}", file=sys.stderr, flush=True)
+        finally:
+            self._close_pipe()
+            print(f"[relay] TCP client disconnected: {peer}", file=sys.stderr, flush=True)
+
+    def _close_pipe(self) -> None:
+        if self.pipe_handle is None:
+            return
+        try:
+            win32file.CloseHandle(self.pipe_handle)
+        except pywintypes.error:
+            pass
+        finally:
+            self.pipe_handle = None
+
+
+class RelayServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Relay TCP frames to the Cheat Engine MCP Windows named pipe."
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST, help=f"TCP bind host (default: {DEFAULT_HOST})")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help=f"TCP bind port (default: {DEFAULT_PORT})")
+    parser.add_argument("--pipe", default=PIPE_NAME, help=f"Named pipe path (default: {PIPE_NAME})")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not 1 <= args.port <= 65535:
+        print("--port must be between 1 and 65535.", file=sys.stderr)
+        return 2
+
+    global PIPE_NAME
+    PIPE_NAME = args.pipe
+
+    print(
+        f"[relay] Listening on {args.host}:{args.port}; forwarding to {PIPE_NAME}",
+        file=sys.stderr,
+        flush=True,
+    )
+    if args.host not in {"127.0.0.1", "localhost", "::1"}:
+        print(
+            "[relay] WARNING: non-loopback bind exposes Cheat Engine control to the network.",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    with RelayServer((args.host, args.port), RelayHandler) as server:
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("\n[relay] Stopping.", file=sys.stderr, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/MCP_Server/mcp_cheatengine.py
+++ b/MCP_Server/mcp_cheatengine.py
@@ -87,6 +87,7 @@ sys.stdout = sys.stderr
 
 # Now safe to import libraries that might print during import
 import json
+import socket
 import struct
 import time
 import math
@@ -94,10 +95,6 @@ import threading
 import traceback
 
 try:
-    import win32file
-    import win32pipe
-    import win32con
-    import pywintypes
     from mcp.server.fastmcp import FastMCP
     
     # CRITICAL: Also patch the reference inside the fastmcp module
@@ -109,6 +106,13 @@ try:
 except ImportError as e:
     print(f"[MCP CE] Import Error: {e}", file=sys.stderr, flush=True)
     sys.exit(1)
+
+try:
+    import win32file
+    import pywintypes
+except ImportError:
+    win32file = None
+    pywintypes = None
 
 # Restore stdout for MCP usage after imports are complete
 sys.stdout = _mcp_stdout
@@ -135,6 +139,8 @@ def format_result(result):
 PIPE_NAME = r"\\.\pipe\CE_MCP_Bridge_v99"
 MCP_SERVER_NAME = "cheatengine"
 MAX_RESPONSE_SIZE_BYTES = 32 * 1024 * 1024
+DEFAULT_TCP_HOST = "127.0.0.1"
+DEFAULT_TCP_PORT = 9876
 
 
 def _parse_timeout_seconds(raw_value):
@@ -154,47 +160,67 @@ def _parse_timeout_seconds(raw_value):
 
 CE_MCP_TIMEOUT_SECONDS = _parse_timeout_seconds(os.environ.get("CE_MCP_TIMEOUT"))
 
+
+def _parse_transport(raw_value):
+    """Parse CE_MCP_TRANSPORT; defaults to Windows named pipe."""
+    transport = (raw_value or "pipe").strip().lower()
+    aliases = {
+        "named_pipe": "pipe",
+        "named-pipe": "pipe",
+        "np": "pipe",
+        "socket": "tcp",
+    }
+    transport = aliases.get(transport, transport)
+    if transport not in {"pipe", "tcp"}:
+        raise ValueError("CE_MCP_TRANSPORT must be 'pipe' or 'tcp'.")
+    return transport
+
+
+def _parse_tcp_port(raw_value):
+    """Parse CE_MCP_PORT as a TCP port number."""
+    if raw_value is None or str(raw_value).strip() == "":
+        return DEFAULT_TCP_PORT
+    try:
+        port = int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("CE_MCP_PORT must be an integer TCP port.") from exc
+    if not 1 <= port <= 65535:
+        raise ValueError("CE_MCP_PORT must be between 1 and 65535.")
+    return port
+
+
+CE_MCP_TRANSPORT = _parse_transport(os.environ.get("CE_MCP_TRANSPORT"))
+CE_MCP_HOST = os.environ.get("CE_MCP_HOST", DEFAULT_TCP_HOST).strip() or DEFAULT_TCP_HOST
+CE_MCP_PORT = _parse_tcp_port(os.environ.get("CE_MCP_PORT"))
+
 # ============================================================================
-# PIPE CLIENT
+# BRIDGE CLIENTS
 # ============================================================================
 
 class CEBridgeClient:
     def __init__(self):
-        self.handle = None
         self.timeout_seconds = CE_MCP_TIMEOUT_SECONDS
 
+    @property
+    def connected(self):
+        raise NotImplementedError
+
     def connect(self):
-        """Attempts to connect to the CE Named Pipe."""
-        try:
-            self.handle = win32file.CreateFile(
-                PIPE_NAME,
-                win32file.GENERIC_READ | win32file.GENERIC_WRITE,
-                0,
-                None,
-                win32file.OPEN_EXISTING,
-                0,
-                None
-            )
-            return True
-        except pywintypes.error as e:
-            # sys.stderr.write(f"[CEBridge] Connect Error: {e}\n")
-            return False
+        raise NotImplementedError
 
     def _exchange_once(self, req_json):
-        """Send one framed request and parse one framed response."""
-        header = struct.pack('<I', len(req_json))
-        win32file.WriteFile(self.handle, header)
-        win32file.WriteFile(self.handle, req_json)
+        raise NotImplementedError
 
-        resp_header_buffer = win32file.ReadFile(self.handle, 4)[1]
-        if len(resp_header_buffer) < 4:
-            raise ConnectionError("Incomplete response header from CE.")
+    def _endpoint_description(self):
+        return "Cheat Engine Bridge"
 
+    def _communication_error(self, error):
+        return error
+
+    def _decode_response(self, resp_header_buffer, resp_body_buffer):
         resp_len = struct.unpack('<I', resp_header_buffer)[0]
         if resp_len > MAX_RESPONSE_SIZE_BYTES:
             raise ConnectionError(f"Response too large: {resp_len} bytes")
-
-        resp_body_buffer = win32file.ReadFile(self.handle, resp_len)[1]
         try:
             return json.loads(resp_body_buffer.decode('utf-8'))
         except json.JSONDecodeError as exc:
@@ -236,9 +262,9 @@ class CEBridgeClient:
         last_error = None
         
         for attempt in range(max_retries):
-            if not self.handle:
+            if not self.connected:
                 if not self.connect():
-                    raise ConnectionError("Cheat Engine Bridge (v12/v99) is not running (Pipe not found).")
+                    raise ConnectionError(f"{self._endpoint_description()} is not reachable.")
 
             request = {
                 "jsonrpc": "2.0",
@@ -258,12 +284,9 @@ class CEBridgeClient:
                     
                 return response
 
-            except (pywintypes.error, ConnectionError, TimeoutError) as e:
+            except (OSError, ConnectionError, TimeoutError) as e:
                 self.close()
-                if isinstance(e, pywintypes.error):
-                    last_error = ConnectionError(f"Pipe Communication failed: {e}")
-                else:
-                    last_error = e
+                last_error = self._communication_error(e)
                 if attempt < max_retries - 1:
                     continue  # Retry
         
@@ -273,14 +296,157 @@ class CEBridgeClient:
         raise ConnectionError("Unknown communication error")
 
     def close(self):
+        raise NotImplementedError
+
+
+class CENamedPipeBridgeClient(CEBridgeClient):
+    def __init__(self):
+        super().__init__()
+        self.handle = None
+        if win32file is None or pywintypes is None:
+            raise RuntimeError(
+                "Named pipe transport requires Windows and pywin32. "
+                "Set CE_MCP_TRANSPORT=tcp when the MCP server cannot open the Windows pipe directly."
+            )
+
+    @property
+    def connected(self):
+        return self.handle is not None
+
+    def connect(self):
+        """Attempts to connect to the CE Named Pipe."""
+        try:
+            self.handle = win32file.CreateFile(
+                PIPE_NAME,
+                win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+                0,
+                None,
+                win32file.OPEN_EXISTING,
+                0,
+                None
+            )
+            return True
+        except pywintypes.error:
+            return False
+
+    def _endpoint_description(self):
+        return "Cheat Engine Bridge (v12/v99 pipe)"
+
+    def _communication_error(self, error):
+        if pywintypes is not None and isinstance(error, pywintypes.error):
+            return ConnectionError(f"Pipe communication failed: {error}")
+        return error
+
+    def _read_exact(self, size):
+        chunks = []
+        remaining = size
+        while remaining > 0:
+            try:
+                chunk = win32file.ReadFile(self.handle, remaining)[1]
+            except pywintypes.error as exc:
+                raise ConnectionError(f"Pipe communication failed: {exc}") from exc
+            if not chunk:
+                raise ConnectionError("Connection closed while reading from CE pipe.")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _exchange_once(self, req_json):
+        """Send one framed request to the named pipe and parse one response."""
+        header = struct.pack('<I', len(req_json))
+        try:
+            win32file.WriteFile(self.handle, header)
+            win32file.WriteFile(self.handle, req_json)
+        except pywintypes.error as exc:
+            raise ConnectionError(f"Pipe communication failed: {exc}") from exc
+
+        resp_header_buffer = self._read_exact(4)
+        resp_len = struct.unpack('<I', resp_header_buffer)[0]
+        if resp_len > MAX_RESPONSE_SIZE_BYTES:
+            raise ConnectionError(f"Response too large: {resp_len} bytes")
+        resp_body_buffer = self._read_exact(resp_len)
+        return self._decode_response(resp_header_buffer, resp_body_buffer)
+
+    def close(self):
         if self.handle:
             try:
                 win32file.CloseHandle(self.handle)
-            except:
+            except Exception:
                 pass
             self.handle = None
 
-ce_client = CEBridgeClient()
+
+class CETcpBridgeClient(CEBridgeClient):
+    def __init__(self, host, port):
+        super().__init__()
+        self.host = host
+        self.port = port
+        self.sock = None
+
+    @property
+    def connected(self):
+        return self.sock is not None
+
+    def connect(self):
+        """Attempts to connect to the TCP relay."""
+        try:
+            connect_timeout = self.timeout_seconds if self.timeout_seconds is not None else None
+            self.sock = socket.create_connection((self.host, self.port), timeout=connect_timeout)
+            self.sock.settimeout(connect_timeout)
+            return True
+        except OSError:
+            self.close()
+            return False
+
+    def _endpoint_description(self):
+        return f"Cheat Engine Bridge TCP relay ({self.host}:{self.port})"
+
+    def _communication_error(self, error):
+        if isinstance(error, OSError):
+            return ConnectionError(f"TCP relay communication failed: {error}")
+        return error
+
+    def _read_exact(self, size):
+        chunks = []
+        remaining = size
+        while remaining > 0:
+            chunk = self.sock.recv(remaining)
+            if not chunk:
+                raise ConnectionError("Connection closed while reading from TCP relay.")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _exchange_once(self, req_json):
+        """Send one framed request to the TCP relay and parse one response."""
+        header = struct.pack('<I', len(req_json))
+        self.sock.sendall(header + req_json)
+
+        resp_header_buffer = self._read_exact(4)
+        resp_len = struct.unpack('<I', resp_header_buffer)[0]
+        if resp_len > MAX_RESPONSE_SIZE_BYTES:
+            raise ConnectionError(f"Response too large: {resp_len} bytes")
+        resp_body_buffer = self._read_exact(resp_len)
+        return self._decode_response(resp_header_buffer, resp_body_buffer)
+
+    def close(self):
+        if self.sock:
+            try:
+                self.sock.close()
+            except OSError:
+                pass
+            self.sock = None
+
+
+def _create_bridge_client():
+    if CE_MCP_TRANSPORT == "tcp":
+        debug_log(f"Using TCP relay transport at {CE_MCP_HOST}:{CE_MCP_PORT}")
+        return CETcpBridgeClient(CE_MCP_HOST, CE_MCP_PORT)
+    debug_log("Using Windows named pipe transport")
+    return CENamedPipeBridgeClient()
+
+
+ce_client = _create_bridge_client()
 
 # ============================================================================
 # MCP SERVER - v12 IMPLEMENTATION

--- a/MCP_Server/requirements-tcp.txt
+++ b/MCP_Server/requirements-tcp.txt
@@ -1,0 +1,6 @@
+# Cheat Engine MCP Bridge - TCP transport dependencies
+# Install in the environment running the MCP server, for example:
+#   python3 -m pip install -r MCP_Server/requirements-tcp.txt
+
+# MCP SDK (Model Context Protocol) - Required for AI agent communication
+mcp>=1.0.0

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pip install mcp pywin32
 ```
 
 > [!NOTE]
-> **Windows only** - Uses Named Pipes (`pywin32`)
+> Native pipe mode is **Windows only** because it uses Named Pipes (`pywin32`). Use TCP relay transport when the MCP server runs outside the Windows environment that hosts Cheat Engine and cannot open the named pipe directly.
 
 ---
 
@@ -134,6 +134,50 @@ args = ['C:\path\to\cheatengine-mcp-bridge\MCP_Server\mcp_cheatengine.py']
 ```
 
 Use single quotes for the Windows path so TOML treats backslashes literally.
+
+#### TCP relay transport
+
+The TCP relay lets `mcp_cheatengine.py` talk to Cheat Engine through a TCP socket instead of opening the Windows named pipe itself. Cheat Engine and the Lua bridge still run on Windows, while the MCP server can run anywhere that can reach the relay: another Windows process, a VM, a container, a Linux host, or a remote machine. This can also be used with WSL without changing the Lua bridge.
+
+1. On Windows, load `MCP_Server/ce_mcp_bridge.lua` in Cheat Engine as usual.
+2. On Windows, start the relay:
+
+```powershell
+python C:\path\to\cheatengine-mcp-bridge\MCP_Server\ce_tcp_relay.py --host 127.0.0.1 --port 9876
+```
+
+3. In the environment where the MCP server will run, install the MCP dependency without `pywin32`, then run/configure the MCP server with TCP transport:
+
+```bash
+python3 -m pip install -r MCP_Server/requirements-tcp.txt
+```
+
+```bash
+CE_MCP_TRANSPORT=tcp \
+CE_MCP_HOST=127.0.0.1 \
+CE_MCP_PORT=9876 \
+python3 /path/to/cheatengine-mcp-bridge/MCP_Server/mcp_cheatengine.py
+```
+
+For MCP client configs that support environment variables:
+
+```json
+{
+  "servers": {
+    "cheatengine": {
+      "command": "python3",
+      "args": ["/path/to/cheatengine-mcp-bridge/MCP_Server/mcp_cheatengine.py"],
+      "env": {
+        "CE_MCP_TRANSPORT": "tcp",
+        "CE_MCP_HOST": "127.0.0.1",
+        "CE_MCP_PORT": "9876"
+      }
+    }
+  }
+}
+```
+
+Set `--host` on the relay and `CE_MCP_HOST` on the MCP server to addresses that match your network setup. Keep the relay bound to trusted interfaces only, because anyone who can reach it can control the Cheat Engine bridge.
 
 ### 3. Verify Connection
 Use the `ping` tool to verify connectivity:


### PR DESCRIPTION
Adds a TCP relay transport option for the Cheat Engine MCP bridge. this keeps the existing windows named-pipe transport as the default while allowing `mcp_cheatengine.py` to connect through a TCP relay when the MCP server cannot open the Windows named pipe directly. It can be used for WSL, VMs, containers, remote hosts or other network separated setups. This does not disrupt original flows.

## Changes
- Add `CE_MCP_TRANSPORT=tcp` support to `mcp_cheatengine.py`
- Add TCP client configuration via:
  - `CE_MCP_HOST`
  - `CE_MCP_PORT`
- Add `ce_tcp_relay.py`, a Windows TCP-to-named-pipe relay
- Add `requirements-tcp.txt` for TCP-only MCP server environments without `pywin32`
- Update README with TCP relay setup instructions
## Notes
- Default behavior remains unchanged. named pipe transport is still used unless `CE_MCP_TRANSPORT=tcp` is set.
- The Lua bridge does not need changes.
- The relay should only be bound to trusted interfaces because it exposes control of the Cheat Engine bridge.